### PR TITLE
Named layer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ E.g Playing a sound, toggling a layer, sending a key sequence, etc...
 - `KeySeq`: Outputs multiple keys at once. E.g `Meh` and `Hyper` are `KeySeq`s
 - `Meh`: A shorthand for `KeySeq(KEY_LEFTCTRL, KEY_LEFTALT, KEY_LEFTSHIFT)`
 - `Hyper`: A shorthand for `KeySeq(KEY_LEFTCTRL, KEY_LEFTALT, KEY_LEFTSHIFT, KEY_LEFTMETA)`
+- `ToggleLayerAlias`: When pressed, either turns on or off a named layer.
 - `ToggleLayer`: When pressed, either turns on or off a layer.
 - `MomentaryLayer`: While pressed, the relevant layer will remain active
 - `Sound`: Plays one of the pre-built sounds

--- a/examples/cfg.ron
+++ b/examples/cfg.ron
@@ -16,6 +16,7 @@
     layer_aliases: {
         0: "base",
         1: "second",
+        3: "skipOne"
     },
     layers: [
         // Layer 0 (Base Layer)
@@ -39,7 +40,10 @@
             KEY_F1:  TapHold(Key(KEY_F1), ToggleLayerAlias("second")),
 
             // F2 on regular tap, layer toggle by index otherwise.
-            KEY_F2:  TapHold(Key(KEY_F2), ToggleLayer(1)),
+            KEY_F2:  TapHold(Key(KEY_F2), ToggleLayer(2)),
+
+            // F4 on regular tap, layer toggle by index otherwise.
+            KEY_F4:  TapHold(Key(KEY_F4), ToggleLayerAlias("skipOne")),
         },
         // Layer 1
         {
@@ -65,5 +69,13 @@
             // Map Shift to Ctrl-Alt-Shift-Win
             KEY_LEFTSHIFT: Tap(Hyper),
         },
+        {
+            // Press once for enter, 2 times for sticky shift
+            KEY_H:   TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
+        },
+        {
+            // Press once for enter, 2 times for sticky shift
+            KEY_G:   TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
+        }
     ],
 )

--- a/examples/cfg.ron
+++ b/examples/cfg.ron
@@ -13,7 +13,10 @@
 
     // ktrl will register a TapDance if all taps occur within a 1000ms period (1s)
     tap_dance_wait_time: 1000,
-
+    layer_aliases: {
+        0: "base",
+        1: "second",
+    },
     layers: [
         // Layer 0 (Base Layer)
         //
@@ -33,7 +36,10 @@
 
             // F1 on regular tap, layer toggle on hold.
             // A toggled layer will stay active until toggled again.
-            KEY_F1:  TapHold(Key(KEY_F1), ToggleLayer(1)),
+            KEY_F1:  TapHold(Key(KEY_F1), ToggleLayerAlias("second")),
+
+            // F2 on regular tap, layer toggle by index otherwise.
+            KEY_F2:  TapHold(Key(KEY_F2), ToggleLayer(1)),
         },
         // Layer 1
         {

--- a/examples/cfg.ron
+++ b/examples/cfg.ron
@@ -13,11 +13,16 @@
 
     // ktrl will register a TapDance if all taps occur within a 1000ms period (1s)
     tap_dance_wait_time: 1000,
+
+    // Gives names to layers
     layer_aliases: {
-        0: "base",
-        1: "second",
-        3: "skipOne"
+        "base": 0,
+        "f_is_enter": 1,
+        "g_is_enter": 2,
+        "h_is_enter": 3,
+        "i_is_enter": 4,
     },
+
     layers: [
         // Layer 0 (Base Layer)
         //
@@ -33,17 +38,20 @@
             // These two lines swap Capslock and Left-Ctrl.
             // As a bonus, an error sound will be played when you press Left-Ctrl
             KEY_CAPSLOCK:  Tap(Key(KEY_LEFTCTRL)),
-            KEY_LEFTCTRL:  Tap(Multi([Key(KEY_LEFTCTRL), Sound(Error)])),
+            KEY_LEFTCTRL:  Tap(Key(KEY_LEFTCTRL)),
 
             // F1 on regular tap, layer toggle on hold.
             // A toggled layer will stay active until toggled again.
-            KEY_F1:  TapHold(Key(KEY_F1), ToggleLayerAlias("second")),
+            KEY_F1:  TapHold(Key(KEY_F1), ToggleLayerAlias("f_is_enter")),
 
             // F2 on regular tap, layer toggle by index otherwise.
             KEY_F2:  TapHold(Key(KEY_F2), ToggleLayer(2)),
 
+            // F2 on regular tap, layer toggle by index otherwise.
+            KEY_F3:  TapHold(Key(KEY_F3), ToggleLayerAlias("h_is_enter")),
+
             // F4 on regular tap, layer toggle by index otherwise.
-            KEY_F4:  TapHold(Key(KEY_F4), ToggleLayerAlias("skipOne")),
+            KEY_F4:  TapHold(Key(KEY_F4), ToggleLayerAlias("i_is_enter")),
         },
         // Layer 1
         {
@@ -58,10 +66,10 @@
 
             // Press once for Enter, press 2 time for Sticky Shift.
             // Sticky keys will remain active until pressed again.
-            KEY_D:   TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
+            KEY_F:   TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
 
-            // Press once for F, press 3 to toggle this layer
-            KEY_F:   TapDance(3, Key(KEY_F), ToggleLayer(1)),
+            // Press once for D, press 3 to toggle this layer
+            KEY_D:   TapDance(3, Key(KEY_D), ToggleLayer(1)),
 
             // Map Alt to Ctrl-Alt-Shift
             KEY_LEFTALT:  Tap(Meh),
@@ -69,13 +77,19 @@
             // Map Shift to Ctrl-Alt-Shift-Win
             KEY_LEFTSHIFT: Tap(Hyper),
         },
+        // Layer 2
+        {
+            // Press once for enter, 2 times for sticky shift
+            KEY_G:   TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
+        },
+        // Layer 3
         {
             // Press once for enter, 2 times for sticky shift
             KEY_H:   TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
         },
+        // Layer 4
         {
-            // Press once for enter, 2 times for sticky shift
-            KEY_G:   TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
+            KEY_I: TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
         }
     ],
 )

--- a/src/actions/tap_dance.rs
+++ b/src/actions/tap_dance.rs
@@ -269,7 +269,7 @@ use crate::effects::Effect::*;
 fn test_tap_dance() {
     use std::collections::HashMap;
     let mut h = HashMap::new();
-    h.insert(0, "base".to_string());
+    h.insert("base".to_string(), 0);
     let cfg = Cfg::new(
         h,
         vec![

--- a/src/actions/tap_dance.rs
+++ b/src/actions/tap_dance.rs
@@ -273,8 +273,9 @@ fn test_tap_dance() {
     let cfg = Cfg::new(
         h,
         vec![
-            (KEY_A, TapDance(3, Key(KEY_A), Key(KEY_LEFTCTRL))),
-        ],
+            vec![
+                (KEY_A, TapDance(3, Key(KEY_A), Key(KEY_LEFTCTRL))),
+            ],
     ]);
 
     let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);

--- a/src/actions/tap_dance.rs
+++ b/src/actions/tap_dance.rs
@@ -267,14 +267,17 @@ use crate::effects::Effect::*;
 
 #[test]
 fn test_tap_dance() {
-    let cfg = Cfg::new(vec![
-        // 0: base layer
+    use std::collections::HashMap;
+    let mut h = HashMap::new();
+    h.insert(0, "base".to_string());
+    let cfg = Cfg::new(
+        h,
         vec![
             (KEY_A, TapDance(3, Key(KEY_A), Key(KEY_LEFTCTRL))),
         ],
     ]);
 
-    let mut l_mgr = LayersManager::new(&cfg.layers);
+    let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
     let mut th_mgr = TapDanceMgr::new(500);
 
     l_mgr.init();

--- a/src/actions/tap_hold.rs
+++ b/src/actions/tap_hold.rs
@@ -389,7 +389,7 @@ fn test_tap() {
 fn test_hold() {
     use std::collections::HashMap;
     let mut h = HashMap::new();
-    h.insert(0, "base".to_string());
+    h.insert("base".to_string(), 0);
     let cfg = Cfg::new(
         h,
         vec![

--- a/src/actions/tap_hold.rs
+++ b/src/actions/tap_hold.rs
@@ -309,8 +309,9 @@ const TEST_TAP_HOLD_WAIT_PERIOD: u64 = 550;
 
 #[test]
 fn test_skipped() {
+    use std::collections::HashMap;
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);
-    let mut l_mgr = LayersManager::new(&vec![]);
+    let mut l_mgr = LayersManager::new(&vec![], &HashMap::new());
     let ev_non_th_press = KeyEvent::new_press(KEY_A);
     let ev_non_th_release = KeyEvent::new_release(KEY_A);
     assert_eq!(th_mgr.process(&mut l_mgr, &ev_non_th_press), OutEffects::empty(CONTINUE));
@@ -320,15 +321,16 @@ fn test_skipped() {
 
 #[test]
 fn test_tap() {
-    let cfg = Cfg::new(vec![
-        // 0: base layer
+    use std::collections::HashMap;
+    let cfg = Cfg::new(
+        HashMap::new(),
         vec![
             (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
             (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
         ],
     ]);
 
-    let mut l_mgr = LayersManager::new(&cfg.layers);
+    let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);
 
     l_mgr.init();
@@ -384,8 +386,11 @@ fn test_tap() {
 
 #[test]
 fn test_hold() {
-    let cfg = Cfg::new(vec![
-        // 0: base layer
+    use std::collections::HashMap;
+    let mut h = HashMap::new();
+    h.insert(0, "base".to_string());
+    let cfg = Cfg::new(
+        h,
         vec![
             (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
             (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),

--- a/src/actions/tap_hold.rs
+++ b/src/actions/tap_hold.rs
@@ -325,9 +325,10 @@ fn test_tap() {
     let cfg = Cfg::new(
         HashMap::new(),
         vec![
-            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
-            (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
-        ],
+            vec![
+                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
+                (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
+            ],
     ]);
 
     let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
@@ -392,12 +393,13 @@ fn test_hold() {
     let cfg = Cfg::new(
         h,
         vec![
-            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
-            (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
-        ],
+            vec![
+                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
+                (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
+            ],
     ]);
 
-    let mut l_mgr = LayersManager::new(&cfg.layers);
+    let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);
 
     l_mgr.init();

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -19,22 +19,17 @@ use std::collections::HashMap;
 #[derive(Debug, Deserialize)]
 pub struct Cfg {
     pub layers: Layers,
-    pub layer_aliases: HashMap<usize, String>,
+    pub layer_aliases: HashMap<String, usize>,
     pub tap_hold_wait_time: u64,
     pub tap_dance_wait_time: u64,
 }
 
 impl Cfg {
     #[cfg(test)]
-    pub fn new(aliases: HashMap<usize, String>, layers: Vec<Vec<(KeyCode, Action)>>) -> Self {
+    pub fn new(layer_aliases: HashMap<String, usize>, layers: Vec<Vec<(KeyCode, Action)>>) -> Self {
         let mut converted: Vec<Layer> = vec![];
-        let mut layer_aliases: HashMap<usize, String> =
-            HashMap::with_capacity(layers.len());
-        for i in 0..layers.len() {
-            if let Some(alias) = aliases.get(&i) {
-                layer_aliases.insert(i, alias.clone());
-            }
-            converted.push(layers[i].clone().into_iter().collect::<Layer>());
+        for layer in layers.into_iter() {
+            converted.push(layer.into_iter().collect::<Layer>());
         }
 
         Self {

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -19,14 +19,6 @@ use std::collections::HashMap;
 #[derive(Debug, Deserialize)]
 pub struct Cfg {
     pub layers: Layers,
-    pub layer_aliases: HashMap<usize, Option<String>>,
-    pub tap_hold_wait_time: u64,
-    pub tap_dance_wait_time: u64,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct PreCfg {
-    pub layers: Layers,
     pub layer_aliases: HashMap<usize, String>,
     pub tap_hold_wait_time: u64,
     pub tap_dance_wait_time: u64,
@@ -36,13 +28,11 @@ impl Cfg {
     #[cfg(test)]
     pub fn new(aliases: HashMap<usize, String>, layers: Vec<Vec<(KeyCode, Action)>>) -> Self {
         let mut converted: Vec<Layer> = vec![];
-        let mut layer_aliases: HashMap<usize, Option<String>> =
+        let mut layer_aliases: HashMap<usize, String> =
             HashMap::with_capacity(layers.len());
         for i in 0..layers.len() {
             if let Some(alias) = aliases.get(&i) {
-                layer_aliases.insert(i, Some(alias.clone()));
-            } else {
-                layer_aliases.insert(i, None);
+                layer_aliases.insert(i, alias.clone());
             }
             converted.push(layers[i].clone().into_iter().collect::<Layer>());
         }
@@ -59,19 +49,5 @@ impl Cfg {
 // ------------------- Util Functions ---------------------
 
 pub fn parse(cfg: &String) -> Cfg {
-    let pre: PreCfg = de::from_str(cfg).expect("Failed to parse the config file");
-    let mut aliases = HashMap::new();
-    for i in 0..pre.layers.len() {
-        if let Some(alias) = pre.layer_aliases.get(&i) {
-            aliases.insert(i, Some(alias.clone()));
-        } else {
-            aliases.insert(i, None);
-        }
-    }
-    Cfg {
-        layers: pre.layers,
-        layer_aliases: aliases,
-        tap_hold_wait_time: pre.tap_hold_wait_time,
-        tap_dance_wait_time: pre.tap_dance_wait_time,
-    }
+    de::from_str(cfg).expect("Failed to parse the config file")
 }

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -9,6 +9,7 @@ use crate::actions::Action;
 
 use ron::de;
 use serde::Deserialize;
+use std::collections::HashMap;
 
 // ------------------- Cfg ---------------------
 
@@ -18,21 +19,39 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 pub struct Cfg {
     pub layers: Layers,
+    pub layer_aliases: HashMap<usize, Option<String>>,
+    pub tap_hold_wait_time: u64,
+    pub tap_dance_wait_time: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PreCfg {
+    pub layers: Layers,
+    pub layer_aliases: HashMap<usize, String>,
     pub tap_hold_wait_time: u64,
     pub tap_dance_wait_time: u64,
 }
 
 impl Cfg {
     #[cfg(test)]
-    pub fn new(layers: Vec<Vec<(KeyCode, Action)>>) -> Self {
+    pub fn new(aliases: HashMap<usize, String>, layers: Vec<Vec<(KeyCode, Action)>>) -> Self {
         let mut converted: Vec<Layer> = vec![];
-        for layer_vec in layers {
-            converted.push(layer_vec.into_iter().collect::<Layer>());
+        let mut layer_aliases: HashMap<usize, Option<String>> =
+            HashMap::with_capacity(layers.len());
+        for i in 0..layers.len() {
+            if let Some(alias) = aliases.get(&i) {
+                layer_aliases.insert(i, Some(alias.clone()));
+            } else {
+                layer_aliases.insert(i, None);
+            }
+            converted.push(layers[i].clone().into_iter().collect::<Layer>());
         }
 
-        Self{layers: converted,
-             tap_hold_wait_time: 0,
-             tap_dance_wait_time: 0,
+        Self {
+            layers: converted,
+            layer_aliases,
+            tap_hold_wait_time: 0,
+            tap_dance_wait_time: 0,
         }
     }
 }
@@ -40,6 +59,19 @@ impl Cfg {
 // ------------------- Util Functions ---------------------
 
 pub fn parse(cfg: &String) -> Cfg {
-    de::from_str(cfg)
-        .expect("Failed to parse the config file")
+    let pre: PreCfg = de::from_str(cfg).expect("Failed to parse the config file");
+    let mut aliases = HashMap::new();
+    for i in 0..pre.layers.len() {
+        if let Some(alias) = pre.layer_aliases.get(&i) {
+            aliases.insert(i, Some(alias.clone()));
+        } else {
+            aliases.insert(i, None);
+        }
+    }
+    Cfg {
+        layers: pre.layers,
+        layer_aliases: aliases,
+        tap_hold_wait_time: pre.tap_hold_wait_time,
+        tap_dance_wait_time: pre.tap_dance_wait_time,
+    }
 }

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -27,6 +27,7 @@ pub enum Effect {
     Meh, // Ctrl+Alt+Shift
     Hyper, // Ctrl+Alt+Shift+Win
 
+    ToggleLayerAlias(String),
     ToggleLayer(LayerIndex),
     MomentaryLayer(LayerIndex),
 

--- a/src/effects/perform.rs
+++ b/src/effects/perform.rs
@@ -75,6 +75,14 @@ fn perform_toggle_layer(ktrl: &mut Ktrl, idx: LayerIndex, value: KeyValue) -> Re
     Ok(())
 }
 
+fn perform_toggle_layer_alias(ktrl: &mut Ktrl, name: String, value: KeyValue) -> Result<(), Error> {
+    if value == KeyValue::Press {
+        ktrl.l_mgr.toggle_layer_alias(name)
+    }
+
+    Ok(())
+}
+
 fn perform_key_sticky(ktrl: &mut Ktrl, code: KeyCode, value: KeyValue) -> Result<(), Error> {
     if value == KeyValue::Release {
         return Ok(());
@@ -110,6 +118,7 @@ pub fn perform_effect(ktrl: &mut Ktrl, fx_val: EffectValue) -> Result<(), Error>
         Effect::Meh => perform_keyseq(&mut ktrl.kbd_out, MEH.to_vec(), fx_val.val),
         Effect::Hyper => perform_keyseq(&mut ktrl.kbd_out, HYPER.to_vec(), fx_val.val),
         Effect::ToggleLayer(idx) => perform_toggle_layer(ktrl, idx, fx_val.val),
+        Effect::ToggleLayerAlias(name) => perform_toggle_layer_alias(ktrl, name, fx_val.val),
         Effect::MomentaryLayer(idx) => perform_momentary_layer(ktrl, idx, fx_val.val),
         Effect::Sound(snd) => perform_play_sound(ktrl, snd, fx_val.val),
         Effect::SoundEx(snd) => perform_play_custom_sound(ktrl, snd, fx_val.val),

--- a/src/ktrl.rs
+++ b/src/ktrl.rs
@@ -53,7 +53,7 @@ impl Ktrl {
 
         let cfg_str = read_to_string(args.config_path)?;
         let cfg = cfg::parse(&cfg_str);
-        let mut l_mgr = LayersManager::new(&cfg.layers);
+        let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
         l_mgr.init();
 
         let th_mgr = TapHoldMgr::new(cfg.tap_hold_wait_time);

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -343,27 +343,28 @@ fn test_mgr() {
     let cfg = Cfg::new(
         h,
         vec![
-            // Ex: switch CTRL <--> Capslock
-            (KEY_LEFTCTRL, Tap(Key(KEY_CAPSLOCK))),
-            (KEY_CAPSLOCK, Tap(Key(KEY_LEFTCTRL))),
-        ],
+            vec![
+                // Ex: switch CTRL <--> Capslock
+                (KEY_LEFTCTRL, Tap(Key(KEY_CAPSLOCK))),
+                (KEY_CAPSLOCK, Tap(Key(KEY_LEFTCTRL))),
+            ],
 
-        // 1: arrows layer
-        vec![
-            // Ex: switch CTRL <--> Capslock
-            (KEY_H, Tap(Key(KEY_LEFT))),
-            (KEY_J, Tap(Key(KEY_DOWN))),
-            (KEY_K, Tap(Key(KEY_UP))),
-            (KEY_L, Tap(Key(KEY_RIGHT))),
-        ],
+            // 1: arrows layer
+            vec![
+                // Ex: switch CTRL <--> Capslock
+                (KEY_H, Tap(Key(KEY_LEFT))),
+                (KEY_J, Tap(Key(KEY_DOWN))),
+                (KEY_K, Tap(Key(KEY_UP))),
+                (KEY_L, Tap(Key(KEY_RIGHT))),
+            ],
 
-        // 2: asdf modifiers
-        vec![
-            // Ex: switch CTRL <--> Capslock
-            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
-            (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTSHIFT))),
-            (KEY_D, TapHold(Key(KEY_D), Key(KEY_LEFTALT))),
-        ],
+            // 2: asdf modifiers
+            vec![
+                // Ex: switch CTRL <--> Capslock
+                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
+                (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTSHIFT))),
+                (KEY_D, TapHold(Key(KEY_D), Key(KEY_LEFTALT))),
+            ],
     ]);
 
     let mut mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
@@ -431,22 +432,25 @@ fn test_mgr() {
 
 #[test]
 fn test_overlapping_keys() {
-        // 0: base layer
-        vec![
-            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))),
-        ],
 
-        // 1: arrows layer
     let mut h = HashMap::new();
     h.insert(0, "base".to_string());
     h.insert(1, "arrows".to_string());
     let cfg = Cfg::new(
         h,
         vec![
+            // 0: base layer
+            vec![
+                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))),
+            ],
+
+            // 1: arrows layer
             // Ex: switch CTRL <--> Capslock
-            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))),
+            vec![
+                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))),
+            ]
         ],
-    ]);
+    );
 
     let mut mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
     mgr.init();

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -17,7 +17,7 @@ const MAX_KEY: usize = KEY_MAX as usize;
 
 pub type LayerIndex = usize;
 pub type Layer = HashMap<KeyCode, Action>;
-pub type LayerAliases = HashMap<LayerIndex, Option<String>>;
+pub type LayerAliases = HashMap<LayerIndex, String>;
 
 #[derive(Clone, Debug)]
 pub struct MergedKey {
@@ -264,25 +264,14 @@ impl LayersManager {
 
     pub fn toggle_layer_alias(&mut self, name: String) {
         if let Some(index) = self.get_idx_from_alias(name) {
-            let is_layer_on = self.layers_states[index];
-
-            if is_layer_on {
-                self.turn_layer_off(index);
-            } else {
-                self.turn_layer_on(index);
-            }
+            self.toggle_layer(index);
         }
     }
 
     fn get_idx_from_alias(&self, name: String) -> Option<usize> {
-        for (idx, op_name) in self.layer_aliases.iter() {
-            match op_name {
-                Some(layer_name) => {
-                    if layer_name == &name {
-                        return Some(idx.clone());
-                    }
-                }
-                None => {}
+        for (idx, layer_name) in self.layer_aliases.iter() {
+            if layer_name == &name {
+                return Some(idx.clone());
             }
         }
         return None;

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -17,7 +17,7 @@ const MAX_KEY: usize = KEY_MAX as usize;
 
 pub type LayerIndex = usize;
 pub type Layer = HashMap<KeyCode, Action>;
-pub type LayerAliases = HashMap<LayerIndex, String>;
+pub type LayerAliases = HashMap<String, LayerIndex>;
 
 #[derive(Clone, Debug)]
 pub struct MergedKey {
@@ -264,17 +264,15 @@ impl LayersManager {
 
     pub fn toggle_layer_alias(&mut self, name: String) {
         if let Some(index) = self.get_idx_from_alias(name) {
-            self.toggle_layer(index);
+            // clone into idx to avoid mutable borrow reservation conflict
+            let idx = index.clone();
+            self.toggle_layer(idx);
         }
     }
 
-    fn get_idx_from_alias(&self, name: String) -> Option<usize> {
-        for (idx, layer_name) in self.layer_aliases.iter() {
-            if layer_name == &name {
-                return Some(idx.clone());
-            }
-        }
-        return None;
+
+    fn get_idx_from_alias(&self, name: String) -> Option<&usize> {
+        self.layer_aliases.get(&name)
     }
 }
 
@@ -326,9 +324,9 @@ use crate::cfg::Cfg;
 #[test]
 fn test_mgr() {
     let mut h = HashMap::new();
-    h.insert(0, "base".to_string());
-    h.insert(1, "arrows".to_string());
-    h.insert(2, "asdf".to_string());
+    h.insert("base".to_string(), 0);
+    h.insert("arrows".to_string(), 1);
+    h.insert("asdf".to_string(), 2);
     let cfg = Cfg::new(
         h,
         vec![
@@ -423,8 +421,8 @@ fn test_mgr() {
 fn test_overlapping_keys() {
 
     let mut h = HashMap::new();
-    h.insert(0, "base".to_string());
-    h.insert(1, "arrows".to_string());
+    h.insert("base".to_string(), 0);
+    h.insert("arrows".to_string(), 1);
     let cfg = Cfg::new(
         h,
         vec![


### PR DESCRIPTION
Here I add `ToggleLayerAlias` support that lets you define names for a layer. To support the desired Cfg format, I had to create a preconfig that doesn't have an `Option<String>`, then create a new an optional layer name for every layer into a `HashMap<index, Option<name>>`. Feel free to rename whatever.

Per #14 