### PR TITLE
Rustfmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ E.g Playing a sound, toggling a layer, sending a key sequence, etc...
 - `KeySeq`: Outputs multiple keys at once. E.g `Meh` and `Hyper` are `KeySeq`s
 - `Meh`: A shorthand for `KeySeq(KEY_LEFTCTRL, KEY_LEFTALT, KEY_LEFTSHIFT)`
 - `Hyper`: A shorthand for `KeySeq(KEY_LEFTCTRL, KEY_LEFTALT, KEY_LEFTSHIFT, KEY_LEFTMETA)`
+- `ToggleLayerAlias`: When pressed, either turns on or off a named layer.
 - `ToggleLayer`: When pressed, either turns on or off a layer.
 - `MomentaryLayer`: While pressed, the relevant layer will remain active
 - `Sound`: Plays one of the pre-built sounds

--- a/examples/cfg.ron
+++ b/examples/cfg.ron
@@ -13,7 +13,10 @@
 
     // ktrl will register a TapDance if all taps occur within a 1000ms period (1s)
     tap_dance_wait_time: 1000,
-
+    layer_aliases: {
+        0: "base",
+        1: "second",
+    },
     layers: [
         // Layer 0 (Base Layer)
         //
@@ -33,7 +36,10 @@
 
             // F1 on regular tap, layer toggle on hold.
             // A toggled layer will stay active until toggled again.
-            KEY_F1:  TapHold(Key(KEY_F1), ToggleLayer(1)),
+            KEY_F1:  TapHold(Key(KEY_F1), ToggleLayerAlias("second")),
+
+            // F2 on regular tap, layer toggle by index otherwise.
+            KEY_F2:  TapHold(Key(KEY_F2), ToggleLayer(1)),
         },
         // Layer 1
         {

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -1,10 +1,10 @@
-pub mod tap_hold;
 pub mod tap_dance;
+pub mod tap_hold;
 
-pub use tap_hold::TapHoldMgr;
-pub use tap_dance::TapDanceMgr;
 use crate::effects::Effect;
 use serde::Deserialize;
+pub use tap_dance::TapDanceMgr;
+pub use tap_hold::TapHoldMgr;
 
 type TapEffect = Effect;
 type HoldEffect = Effect;
@@ -15,10 +15,8 @@ type DanceLength = usize;
 pub enum Action {
     Tap(Effect),
     TapHold(TapEffect, HoldEffect),
-    TapDance(DanceLength, TapEffect, DanceEffect)
-
-    // Not Implemented Yet
-    // -------------------
-    // Sequence(Vec<KeyCode>, Effect),
-    // Combo(Vec<KeyCode>, Effect),
+    TapDance(DanceLength, TapEffect, DanceEffect), // Not Implemented Yet
+                                                   // -------------------
+                                                   // Sequence(Vec<KeyCode>, Effect),
+                                                   // Combo(Vec<KeyCode>, Effect)
 }

--- a/src/actions/tap_dance.rs
+++ b/src/actions/tap_dance.rs
@@ -1,20 +1,16 @@
 // std
 // ktrl
-use crate::layers::LockOwner;
-use crate::layers::LayersManager;
-use crate::keys::KeyCode;
-use crate::keys::KeyValue;
-use crate::keys::KeyEvent;
 use crate::effects::OutEffects;
+use crate::keys::KeyCode;
+use crate::keys::KeyEvent;
+use crate::keys::KeyValue;
+use crate::layers::LayersManager;
+use crate::layers::LockOwner;
 
 // inner
 use inner::inner;
 
-use crate::layers::{
-    Effect,
-    Action,
-    Action::TapDance,
-};
+use crate::layers::{Action, Action::TapDance, Effect};
 
 const STOP: bool = true;
 const CONTINUE: bool = false;
@@ -31,9 +27,11 @@ struct TapDanceCfg {
 impl TapDanceCfg {
     fn from_action(action: &Action) -> Self {
         match action {
-            TapDance(len, tap_fx, dance_fx) => Self{len: *len,
-                                                    tap_fx: tap_fx.clone(),
-                                                    dance_fx: dance_fx.clone()},
+            TapDance(len, tap_fx, dance_fx) => Self {
+                len: *len,
+                tap_fx: tap_fx.clone(),
+                dance_fx: dance_fx.clone(),
+            },
             _ => unreachable!(),
         }
     }
@@ -63,9 +61,11 @@ pub struct TapDanceMgr {
 impl TapDanceMgr {
     pub fn new(wait_time: u64) -> Self {
         assert!(wait_time < (i64::MAX as u64));
-        Self{state: TapDanceState::TdIdle,
-             dancing: None,
-             wait_time}
+        Self {
+            state: TapDanceState::TdIdle,
+            dancing: None,
+            wait_time,
+        }
     }
 
     fn lock_key(l_mgr: &mut LayersManager, key: KeyCode) {
@@ -93,17 +93,21 @@ impl TapDanceMgr {
 
     fn did_dance_timeout(&self, event: &KeyEvent) -> bool {
         let new_timestamp = event.time.clone();
-        let wait_start_timestamp = inner!(&self.state, if TapDanceState::TdDancing).timestamp.clone();
+        let wait_start_timestamp = inner!(&self.state, if TapDanceState::TdDancing)
+            .timestamp
+            .clone();
         let secs_diff = new_timestamp.tv_sec - wait_start_timestamp.tv_sec;
-        let usecs_diff  = new_timestamp.tv_usec - wait_start_timestamp.tv_usec;
+        let usecs_diff = new_timestamp.tv_usec - wait_start_timestamp.tv_usec;
         let diff = (secs_diff * 1_000_000) + usecs_diff;
         diff >= (self.wait_time as i64) * 1000
     }
 
-    fn handle_th_dancing(&mut self,
-                         l_mgr: &mut LayersManager,
-                         event: &KeyEvent,
-                         td_cfg: &TapDanceCfg) -> OutEffects {
+    fn handle_th_dancing(
+        &mut self,
+        l_mgr: &mut LayersManager,
+        event: &KeyEvent,
+        td_cfg: &TapDanceCfg,
+    ) -> OutEffects {
         let did_timeout = self.did_dance_timeout(event);
         let did_key_change = event.code != self.dancing.unwrap().clone();
 
@@ -113,7 +117,7 @@ impl TapDanceMgr {
             self.clear_dancing(l_mgr);
             let idle_out = self.handle_th_idle(l_mgr, event, td_cfg);
             if let Some(mut new_fx_vals) = idle_out.effects {
-                 fx_vals.append(&mut new_fx_vals);
+                fx_vals.append(&mut new_fx_vals);
             }
             return OutEffects::new_multiple(STOP, fx_vals);
         }
@@ -132,7 +136,7 @@ impl TapDanceMgr {
                     self.state = TapDanceState::TdDancing(new_state);
                     OutEffects::empty(STOP)
                 }
-            },
+            }
             KeyValue::Release => {
                 let mut new_state = wait_state.clone();
                 new_state.releases_so_far += 1;
@@ -145,7 +149,7 @@ impl TapDanceMgr {
                     self.state = TapDanceState::TdDancing(new_state);
                     OutEffects::empty(STOP)
                 }
-            },
+            }
 
             KeyValue::Repeat => {
                 // Drop repeats. These aren't supported for TapDances
@@ -154,10 +158,12 @@ impl TapDanceMgr {
         }
     }
 
-    fn handle_th_idle(&mut self,
-                      l_mgr: &mut LayersManager,
-                      event: &KeyEvent,
-                      td_cfg: &TapDanceCfg) -> OutEffects {
+    fn handle_th_idle(
+        &mut self,
+        l_mgr: &mut LayersManager,
+        event: &KeyEvent,
+        td_cfg: &TapDanceCfg,
+    ) -> OutEffects {
         assert!(self.state == TapDanceState::TdIdle);
 
         let keycode: KeyCode = event.code;
@@ -165,19 +171,19 @@ impl TapDanceMgr {
 
         match value {
             KeyValue::Press => {
-                self.state = TapDanceState::TdDancing(
-                    TapDanceWaiting{timestamp: event.time.clone(),
-                                    presses_so_far: 1,
-                                    releases_so_far: 0}
-                );
+                self.state = TapDanceState::TdDancing(TapDanceWaiting {
+                    timestamp: event.time.clone(),
+                    presses_so_far: 1,
+                    releases_so_far: 0,
+                });
                 self.set_dancing(l_mgr, keycode);
                 OutEffects::empty(STOP)
-            },
+            }
 
             KeyValue::Release => {
                 // Forward the release
                 OutEffects::new(STOP, td_cfg.tap_fx.clone(), KeyValue::Release)
-            },
+            }
 
             KeyValue::Repeat => {
                 // Drop repeats. These aren't supported for TapDances
@@ -187,12 +193,14 @@ impl TapDanceMgr {
     }
 
     // Assumes this is an event tied to a TapDance assigned MergedKey
-    fn process_tap_dance_key(&mut self,
-                            l_mgr: &mut LayersManager,
-                            event: &KeyEvent,
-                            td_cfg: &TapDanceCfg) -> OutEffects {
+    fn process_tap_dance_key(
+        &mut self,
+        l_mgr: &mut LayersManager,
+        event: &KeyEvent,
+        td_cfg: &TapDanceCfg,
+    ) -> OutEffects {
         let state = &self.state;
-        match state{
+        match state {
             TapDanceState::TdIdle => self.handle_th_idle(l_mgr, event, td_cfg),
             TapDanceState::TdDancing(_) => self.handle_th_dancing(l_mgr, event, td_cfg),
         }
@@ -214,13 +222,13 @@ impl TapDanceMgr {
         out
     }
 
-    fn process_non_tap_dance_key(&mut self,
-                                l_mgr: &mut LayersManager,
-                                _event: &KeyEvent) -> OutEffects {
+    fn process_non_tap_dance_key(
+        &mut self,
+        l_mgr: &mut LayersManager,
+        _event: &KeyEvent,
+    ) -> OutEffects {
         match self.dancing {
-            None => {
-                OutEffects::empty(CONTINUE)
-            },
+            None => OutEffects::empty(CONTINUE),
 
             Some(dancing) => {
                 let action = &l_mgr.get(dancing).action;
@@ -261,9 +269,9 @@ impl TapDanceMgr {
 #[cfg(test)]
 use crate::cfg::*;
 #[cfg(test)]
-use crate::keys::KeyCode::*;
-#[cfg(test)]
 use crate::effects::Effect::*;
+#[cfg(test)]
+use crate::keys::KeyCode::*;
 
 #[test]
 fn test_tap_dance() {
@@ -272,11 +280,8 @@ fn test_tap_dance() {
     h.insert(0, "base".to_string());
     let cfg = Cfg::new(
         h,
-        vec![
-            vec![
-                (KEY_A, TapDance(3, Key(KEY_A), Key(KEY_LEFTCTRL))),
-            ],
-    ]);
+        vec![vec![(KEY_A, TapDance(3, Key(KEY_A), Key(KEY_LEFTCTRL)))]],
+    );
 
     let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
     let mut th_mgr = TapDanceMgr::new(500);
@@ -287,20 +292,38 @@ fn test_tap_dance() {
     let ev_th_release = KeyEvent::new_release(KEY_A);
 
     // 1st
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_press), OutEffects::empty(STOP));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_press),
+        OutEffects::empty(STOP)
+    );
     assert_eq!(th_mgr.is_idle(), false);
     assert_eq!(l_mgr.is_key_locked(KEY_A), true);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_release), OutEffects::empty(STOP));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_release),
+        OutEffects::empty(STOP)
+    );
 
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_press), OutEffects::empty(STOP));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_press),
+        OutEffects::empty(STOP)
+    );
     assert_eq!(th_mgr.is_idle(), false);
     assert_eq!(l_mgr.is_key_locked(KEY_A), true);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_release), OutEffects::empty(STOP));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_release),
+        OutEffects::empty(STOP)
+    );
 
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_press), OutEffects::new(STOP, Key(KEY_LEFTCTRL), KeyValue::Press));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_press),
+        OutEffects::new(STOP, Key(KEY_LEFTCTRL), KeyValue::Press)
+    );
     assert_eq!(th_mgr.is_idle(), false);
     assert_eq!(l_mgr.is_key_locked(KEY_A), true);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_release), OutEffects::new(STOP, Key(KEY_LEFTCTRL), KeyValue::Release));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_release),
+        OutEffects::new(STOP, Key(KEY_LEFTCTRL), KeyValue::Release)
+    );
 
     assert_eq!(th_mgr.is_idle(), true);
     assert_eq!(l_mgr.is_key_locked(KEY_A), false);

--- a/src/actions/tap_dance.rs
+++ b/src/actions/tap_dance.rs
@@ -273,8 +273,9 @@ fn test_tap_dance() {
     let cfg = Cfg::new(
         h,
         vec![
-            (KEY_A, TapDance(3, Key(KEY_A), Key(KEY_LEFTCTRL))),
-        ],
+            vec![
+                (KEY_A, TapDance(3, Key(KEY_A), Key(KEY_LEFTCTRL))),
+            ],
     ]);
 
     let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);

--- a/src/actions/tap_dance.rs
+++ b/src/actions/tap_dance.rs
@@ -267,14 +267,17 @@ use crate::effects::Effect::*;
 
 #[test]
 fn test_tap_dance() {
-    let cfg = Cfg::new(vec![
-        // 0: base layer
+    use std::collections::HashMap;
+    let mut h = HashMap::new();
+    h.insert(0, "base".to_string());
+    let cfg = Cfg::new(
+        h,
         vec![
             (KEY_A, TapDance(3, Key(KEY_A), Key(KEY_LEFTCTRL))),
         ],
     ]);
 
-    let mut l_mgr = LayersManager::new(&cfg.layers);
+    let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
     let mut th_mgr = TapDanceMgr::new(500);
 
     l_mgr.init();

--- a/src/actions/tap_hold.rs
+++ b/src/actions/tap_hold.rs
@@ -1,24 +1,20 @@
 // std
-use std::vec::Vec;
 use std::collections::HashSet;
+use std::vec::Vec;
 
 // ktrl
-use crate::layers::LockOwner;
-use crate::layers::LayersManager;
-use crate::keys::KeyCode;
-use crate::keys::KeyValue;
-use crate::keys::KeyEvent;
 use crate::effects::EffectValue;
 use crate::effects::OutEffects;
+use crate::keys::KeyCode;
+use crate::keys::KeyEvent;
+use crate::keys::KeyValue;
+use crate::layers::LayersManager;
+use crate::layers::LockOwner;
 
 // inner
 use inner::inner;
 
-use crate::layers::{
-    Effect,
-    Action,
-    Action::TapHold,
-};
+use crate::layers::{Action, Action::TapHold, Effect};
 
 const STOP: bool = true;
 const CONTINUE: bool = false;
@@ -34,8 +30,10 @@ struct TapHoldCfg {
 impl TapHoldCfg {
     fn from_action(action: &Action) -> Self {
         match action {
-            TapHold(tap_fx, hold_fx) => Self{tap_fx: tap_fx.clone(),
-                                             hold_fx: hold_fx.clone()},
+            TapHold(tap_fx, hold_fx) => Self {
+                tap_fx: tap_fx.clone(),
+                hold_fx: hold_fx.clone(),
+            },
             _ => unreachable!(),
         }
     }
@@ -75,10 +73,12 @@ impl TapHoldMgr {
         let mut states = Vec::new();
         states.resize_with(KeyCode::KEY_MAX as usize, || TapHoldState::ThIdle);
 
-        Self{states,
-             waiting_keys: Vec::new(),
-             holding_keys: HashSet::new(),
-             wait_time}
+        Self {
+            states,
+            waiting_keys: Vec::new(),
+            holding_keys: HashSet::new(),
+            wait_time,
+        }
     }
 
     fn lock_key(l_mgr: &mut LayersManager, key: KeyCode) {
@@ -110,10 +110,12 @@ impl TapHoldMgr {
         Self::unlock_key(l_mgr, key);
     }
 
-    fn handle_th_holding(&mut self,
-                         l_mgr: &mut LayersManager,
-                         event: &KeyEvent,
-                         th_cfg: &TapHoldCfg) -> OutEffects {
+    fn handle_th_holding(
+        &mut self,
+        l_mgr: &mut LayersManager,
+        event: &KeyEvent,
+        th_cfg: &TapHoldCfg,
+    ) -> OutEffects {
         let state = &mut self.states[event.code as usize];
         assert!(*state == TapHoldState::ThHolding);
         let value = KeyValue::from(event.value);
@@ -123,15 +125,16 @@ impl TapHoldMgr {
                 // Should never happen.
                 // Should only see this in the idle state
                 unreachable!()
-            },
+            }
 
             KeyValue::Release => {
                 // Cleanup the hold
                 *state = TapHoldState::ThIdle;
                 self.clear_waiting(l_mgr);
                 self.remove_holding(l_mgr, event.code);
-                OutEffects::new(STOP, th_cfg.hold_fx.clone(), KeyValue::Release) // forward the release
-            },
+                OutEffects::new(STOP, th_cfg.hold_fx.clone(), KeyValue::Release)
+                // forward the release
+            }
 
             KeyValue::Repeat => {
                 // Drop repeats. These aren't supported for TapHolds
@@ -140,10 +143,12 @@ impl TapHoldMgr {
         }
     }
 
-    fn handle_th_waiting(&mut self,
-                         l_mgr: &mut LayersManager,
-                         event: &KeyEvent,
-                         th_cfg: &TapHoldCfg) -> OutEffects {
+    fn handle_th_waiting(
+        &mut self,
+        l_mgr: &mut LayersManager,
+        event: &KeyEvent,
+        th_cfg: &TapHoldCfg,
+    ) -> OutEffects {
         let value = KeyValue::from(event.value);
 
         match value {
@@ -151,7 +156,7 @@ impl TapHoldMgr {
                 // Should never happen.
                 // Should only see this in the idle state
                 unreachable!()
-            },
+            }
 
             KeyValue::Release => {
                 let state = &self.states[event.code as usize];
@@ -162,17 +167,23 @@ impl TapHoldMgr {
 
                 self.clear_waiting(l_mgr);
                 if is_wait_over {
-                    OutEffects::new_multiple(STOP, vec![
-                        EffectValue::new(th_cfg.hold_fx.clone(), KeyValue::Press),
-                        EffectValue::new(th_cfg.hold_fx.clone(), KeyValue::Release)
-                    ])
+                    OutEffects::new_multiple(
+                        STOP,
+                        vec![
+                            EffectValue::new(th_cfg.hold_fx.clone(), KeyValue::Press),
+                            EffectValue::new(th_cfg.hold_fx.clone(), KeyValue::Release),
+                        ],
+                    )
                 } else {
-                    OutEffects::new_multiple(STOP, vec![
-                        EffectValue::new(th_cfg.tap_fx.clone(), KeyValue::Press),
-                        EffectValue::new(th_cfg.tap_fx.clone(), KeyValue::Release)
-                    ])
+                    OutEffects::new_multiple(
+                        STOP,
+                        vec![
+                            EffectValue::new(th_cfg.tap_fx.clone(), KeyValue::Press),
+                            EffectValue::new(th_cfg.tap_fx.clone(), KeyValue::Release),
+                        ],
+                    )
                 }
-            },
+            }
 
             KeyValue::Repeat => {
                 // Drop repeats. These aren't supported for TapHolds
@@ -181,10 +192,12 @@ impl TapHoldMgr {
         }
     }
 
-    fn handle_th_idle(&mut self,
-                      l_mgr: &mut LayersManager,
-                      event: &KeyEvent,
-                      th_cfg: &TapHoldCfg) -> OutEffects {
+    fn handle_th_idle(
+        &mut self,
+        l_mgr: &mut LayersManager,
+        event: &KeyEvent,
+        th_cfg: &TapHoldCfg,
+    ) -> OutEffects {
         let state = &mut self.states[event.code as usize];
         assert!(*state == TapHoldState::ThIdle);
 
@@ -196,17 +209,17 @@ impl TapHoldMgr {
                 // Transition to the waiting state.
                 // I.E waiting for either an interruptions => Press+Release the Tap effect
                 // or for the TapHold wait period => Send a Hold effect press
-                *state = TapHoldState::ThWaiting(
-                    TapHoldWaiting{timestamp: event.time.clone()}
-                );
+                *state = TapHoldState::ThWaiting(TapHoldWaiting {
+                    timestamp: event.time.clone(),
+                });
                 self.insert_waiting(l_mgr, keycode);
                 OutEffects::empty(STOP)
-            },
+            }
 
             KeyValue::Release => {
                 // Forward the release
                 OutEffects::new(STOP, th_cfg.tap_fx.clone(), KeyValue::Release)
-            },
+            }
 
             KeyValue::Repeat => {
                 // Drop repeats. These aren't supported for TapHolds
@@ -216,10 +229,12 @@ impl TapHoldMgr {
     }
 
     // Assumes this is an event tied to a TapHold assigned MergedKey
-    fn process_tap_hold_key(&mut self,
-                            l_mgr: &mut LayersManager,
-                            event: &KeyEvent,
-                            th_cfg: &TapHoldCfg) -> OutEffects {
+    fn process_tap_hold_key(
+        &mut self,
+        l_mgr: &mut LayersManager,
+        event: &KeyEvent,
+        th_cfg: &TapHoldCfg,
+    ) -> OutEffects {
         match self.states[event.code as usize] {
             TapHoldState::ThIdle => self.handle_th_idle(l_mgr, event, th_cfg),
             TapHoldState::ThWaiting(_) => self.handle_th_waiting(l_mgr, event, th_cfg),
@@ -231,17 +246,21 @@ impl TapHoldMgr {
 
     fn is_waiting_over(&self, key_state: &TapHoldState, event: &KeyEvent) -> bool {
         let new_timestamp = event.time.clone();
-        let wait_start_timestamp = inner!(key_state, if TapHoldState::ThWaiting).timestamp.clone();
+        let wait_start_timestamp = inner!(key_state, if TapHoldState::ThWaiting)
+            .timestamp
+            .clone();
 
         let secs_diff = new_timestamp.tv_sec - wait_start_timestamp.tv_sec;
-        let usecs_diff  = new_timestamp.tv_usec - wait_start_timestamp.tv_usec;
+        let usecs_diff = new_timestamp.tv_usec - wait_start_timestamp.tv_usec;
         let diff = (secs_diff * 1_000_000) + usecs_diff;
         diff >= (self.wait_time as i64) * 1000
     }
 
-    fn process_non_tap_hold_key(&mut self,
-                                l_mgr: &mut LayersManager,
-                                event: &KeyEvent) -> OutEffects {
+    fn process_non_tap_hold_key(
+        &mut self,
+        l_mgr: &mut LayersManager,
+        event: &KeyEvent,
+    ) -> OutEffects {
         let mut out = OutEffects::empty(CONTINUE);
         let waiting_keys: Vec<KeyCode> = self.waiting_keys.drain(..).collect();
 
@@ -260,7 +279,6 @@ impl TapHoldMgr {
                 let state = &mut self.states[waiting as usize];
                 *state = TapHoldState::ThHolding;
                 self.insert_holding(l_mgr, waiting);
-
             } else {
                 // Flush the press and release tap_fx
                 out.insert(th_cfg.tap_fx, KeyValue::Press);
@@ -289,20 +307,18 @@ impl TapHoldMgr {
         }
     }
 
-
     #[cfg(test)]
     pub fn is_idle(&self) -> bool {
-        self.waiting_keys.len() == 0 &&
-            self.holding_keys.len() == 0
+        self.waiting_keys.len() == 0 && self.holding_keys.len() == 0
     }
 }
 
 #[cfg(test)]
 use crate::cfg::*;
 #[cfg(test)]
-use crate::keys::KeyCode::*;
-#[cfg(test)]
 use crate::effects::Effect::*;
+#[cfg(test)]
+use crate::keys::KeyCode::*;
 
 #[cfg(test)]
 const TEST_TAP_HOLD_WAIT_PERIOD: u64 = 550;
@@ -314,8 +330,14 @@ fn test_skipped() {
     let mut l_mgr = LayersManager::new(&vec![], &HashMap::new());
     let ev_non_th_press = KeyEvent::new_press(KEY_A);
     let ev_non_th_release = KeyEvent::new_release(KEY_A);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_non_th_press), OutEffects::empty(CONTINUE));
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_non_th_release), OutEffects::empty(CONTINUE));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_non_th_press),
+        OutEffects::empty(CONTINUE)
+    );
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_non_th_release),
+        OutEffects::empty(CONTINUE)
+    );
     assert_eq!(th_mgr.is_idle(), true);
 }
 
@@ -324,12 +346,11 @@ fn test_tap() {
     use std::collections::HashMap;
     let cfg = Cfg::new(
         HashMap::new(),
-        vec![
-            vec![
-                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
-                (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
-            ],
-    ]);
+        vec![vec![
+            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
+            (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
+        ]],
+    );
 
     let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);
@@ -341,24 +362,42 @@ fn test_tap() {
     ev_th_release.time.tv_usec += 100;
 
     // 1st
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_press), OutEffects::empty(STOP));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_press),
+        OutEffects::empty(STOP)
+    );
     assert_eq!(th_mgr.is_idle(), false);
     assert_eq!(l_mgr.is_key_locked(KEY_A), true);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_release), OutEffects::new_multiple(STOP, vec![
-        EffectValue::new(Effect::Key(KEY_A.into()), KeyValue::Press),
-        EffectValue::new(Effect::Key(KEY_A.into()), KeyValue::Release),
-    ]));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_release),
+        OutEffects::new_multiple(
+            STOP,
+            vec![
+                EffectValue::new(Effect::Key(KEY_A.into()), KeyValue::Press),
+                EffectValue::new(Effect::Key(KEY_A.into()), KeyValue::Release),
+            ]
+        )
+    );
     assert_eq!(th_mgr.is_idle(), true);
     assert_eq!(l_mgr.is_key_locked(KEY_A), false);
 
     // 2nd
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_press), OutEffects::empty(STOP));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_press),
+        OutEffects::empty(STOP)
+    );
     assert_eq!(th_mgr.is_idle(), false);
     assert_eq!(l_mgr.is_key_locked(KEY_A), true);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_release), OutEffects::new_multiple(STOP, vec![
-        EffectValue::new(Effect::Key(KEY_A.into()), KeyValue::Press),
-        EffectValue::new(Effect::Key(KEY_A.into()), KeyValue::Release),
-    ]));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_release),
+        OutEffects::new_multiple(
+            STOP,
+            vec![
+                EffectValue::new(Effect::Key(KEY_A.into()), KeyValue::Press),
+                EffectValue::new(Effect::Key(KEY_A.into()), KeyValue::Release),
+            ]
+        )
+    );
     assert_eq!(th_mgr.is_idle(), true);
     assert_eq!(l_mgr.is_key_locked(KEY_A), false);
 
@@ -366,20 +405,44 @@ fn test_tap() {
     ev_th_release.time.tv_usec = (TEST_TAP_HOLD_WAIT_PERIOD * 1000 + 1) as i64;
     let ev_non_th_press = KeyEvent::new_press(KEY_W);
     let ev_non_th_release = KeyEvent::new_release(KEY_W);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_press), OutEffects::empty(STOP));
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_non_th_press), OutEffects::new(CONTINUE, Effect::Key(KEY_A.into()), KeyValue::Press));
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_release), OutEffects::new(STOP, Effect::Key(KEY_A.into()), KeyValue::Release));
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_non_th_release), OutEffects::empty(CONTINUE));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_press),
+        OutEffects::empty(STOP)
+    );
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_non_th_press),
+        OutEffects::new(CONTINUE, Effect::Key(KEY_A.into()), KeyValue::Press)
+    );
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_release),
+        OutEffects::new(STOP, Effect::Key(KEY_A.into()), KeyValue::Release)
+    );
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_non_th_release),
+        OutEffects::empty(CONTINUE)
+    );
     assert_eq!(th_mgr.is_idle(), true);
 
     // interruptions: 2
     ev_th_release.time.tv_usec = (TEST_TAP_HOLD_WAIT_PERIOD * 1000 + 1) as i64;
     let ev_non_th_press = KeyEvent::new_press(KEY_W);
     let ev_non_th_release = KeyEvent::new_release(KEY_W);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_press), OutEffects::empty(STOP));
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_non_th_press), OutEffects::new(CONTINUE, Effect::Key(KEY_A.into()), KeyValue::Press));
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_non_th_release), OutEffects::empty(CONTINUE));
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_release), OutEffects::new(STOP, Effect::Key(KEY_A.into()), KeyValue::Release));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_press),
+        OutEffects::empty(STOP)
+    );
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_non_th_press),
+        OutEffects::new(CONTINUE, Effect::Key(KEY_A.into()), KeyValue::Press)
+    );
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_non_th_release),
+        OutEffects::empty(CONTINUE)
+    );
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_release),
+        OutEffects::new(STOP, Effect::Key(KEY_A.into()), KeyValue::Release)
+    );
     assert_eq!(th_mgr.is_idle(), true);
     assert_eq!(l_mgr.is_key_locked(KEY_A), false);
     assert_eq!(l_mgr.is_key_locked(KEY_W), false);
@@ -392,12 +455,11 @@ fn test_hold() {
     h.insert(0, "base".to_string());
     let cfg = Cfg::new(
         h,
-        vec![
-            vec![
-                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
-                (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
-            ],
-    ]);
+        vec![vec![
+            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
+            (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
+        ]],
+    );
 
     let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);
@@ -409,15 +471,23 @@ fn test_hold() {
     ev_th_release.time.tv_usec = 1;
 
     // No hold + other key chord
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_press), OutEffects::empty(STOP));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_press),
+        OutEffects::empty(STOP)
+    );
     assert_eq!(l_mgr.is_key_locked(KEY_A), true);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_release), OutEffects::new_multiple(STOP, vec![
-        EffectValue::new(Effect::Key(KEY_A.into()), KeyValue::Press),
-        EffectValue::new(Effect::Key(KEY_A.into()), KeyValue::Release),
-    ]));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_release),
+        OutEffects::new_multiple(
+            STOP,
+            vec![
+                EffectValue::new(Effect::Key(KEY_A.into()), KeyValue::Press),
+                EffectValue::new(Effect::Key(KEY_A.into()), KeyValue::Release),
+            ]
+        )
+    );
     assert_eq!(th_mgr.is_idle(), true);
     assert_eq!(l_mgr.is_key_locked(KEY_A), false);
-
 
     // -------------------------------
 
@@ -428,13 +498,25 @@ fn test_hold() {
     ev_non_th_release.time.tv_usec = (TEST_TAP_HOLD_WAIT_PERIOD * 1000 + 2) as i64;
     ev_th_release.time.tv_usec = (TEST_TAP_HOLD_WAIT_PERIOD * 1000 + 3) as i64;
 
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_press), OutEffects::empty(STOP));
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_non_th_press), OutEffects::new(CONTINUE, Effect::Key(KEY_LEFTCTRL.into()), KeyValue::Press));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_press),
+        OutEffects::empty(STOP)
+    );
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_non_th_press),
+        OutEffects::new(CONTINUE, Effect::Key(KEY_LEFTCTRL.into()), KeyValue::Press)
+    );
     assert_eq!(th_mgr.is_idle(), false);
     assert_eq!(l_mgr.is_key_locked(KEY_A), true);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_non_th_release), OutEffects::empty(CONTINUE));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_non_th_release),
+        OutEffects::empty(CONTINUE)
+    );
     assert_eq!(l_mgr.is_key_locked(KEY_A), true);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_release), OutEffects::new(STOP, Effect::Key(KEY_LEFTCTRL.into()), KeyValue::Release));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_release),
+        OutEffects::new(STOP, Effect::Key(KEY_LEFTCTRL.into()), KeyValue::Release)
+    );
     assert_eq!(l_mgr.is_key_locked(KEY_A), false);
 
     // -------------------------------
@@ -444,12 +526,24 @@ fn test_hold() {
     ev_th_release.time.tv_usec = (TEST_TAP_HOLD_WAIT_PERIOD * 1000 + 2) as i64;
     ev_non_th_release.time.tv_usec = (TEST_TAP_HOLD_WAIT_PERIOD * 1000 + 3) as i64;
 
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_press), OutEffects::empty(STOP));
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_non_th_press), OutEffects::new(CONTINUE, Effect::Key(KEY_LEFTCTRL.into()), KeyValue::Press));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_press),
+        OutEffects::empty(STOP)
+    );
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_non_th_press),
+        OutEffects::new(CONTINUE, Effect::Key(KEY_LEFTCTRL.into()), KeyValue::Press)
+    );
     assert_eq!(th_mgr.is_idle(), false);
     assert_eq!(l_mgr.is_key_locked(KEY_A), true);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_th_release), OutEffects::new(STOP, Effect::Key(KEY_LEFTCTRL.into()), KeyValue::Release));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_th_release),
+        OutEffects::new(STOP, Effect::Key(KEY_LEFTCTRL.into()), KeyValue::Release)
+    );
     assert_eq!(l_mgr.is_key_locked(KEY_A), false);
-    assert_eq!(th_mgr.process(&mut l_mgr, &ev_non_th_release), OutEffects::empty(CONTINUE));
+    assert_eq!(
+        th_mgr.process(&mut l_mgr, &ev_non_th_release),
+        OutEffects::empty(CONTINUE)
+    );
     assert_eq!(l_mgr.is_key_locked(KEY_A), false);
 }

--- a/src/actions/tap_hold.rs
+++ b/src/actions/tap_hold.rs
@@ -309,8 +309,9 @@ const TEST_TAP_HOLD_WAIT_PERIOD: u64 = 550;
 
 #[test]
 fn test_skipped() {
+    use std::collections::HashMap;
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);
-    let mut l_mgr = LayersManager::new(&vec![]);
+    let mut l_mgr = LayersManager::new(&vec![], &HashMap::new());
     let ev_non_th_press = KeyEvent::new_press(KEY_A);
     let ev_non_th_release = KeyEvent::new_release(KEY_A);
     assert_eq!(th_mgr.process(&mut l_mgr, &ev_non_th_press), OutEffects::empty(CONTINUE));
@@ -320,15 +321,16 @@ fn test_skipped() {
 
 #[test]
 fn test_tap() {
-    let cfg = Cfg::new(vec![
-        // 0: base layer
+    use std::collections::HashMap;
+    let cfg = Cfg::new(
+        HashMap::new(),
         vec![
             (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
             (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
         ],
     ]);
 
-    let mut l_mgr = LayersManager::new(&cfg.layers);
+    let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);
 
     l_mgr.init();
@@ -384,8 +386,11 @@ fn test_tap() {
 
 #[test]
 fn test_hold() {
-    let cfg = Cfg::new(vec![
-        // 0: base layer
+    use std::collections::HashMap;
+    let mut h = HashMap::new();
+    h.insert(0, "base".to_string());
+    let cfg = Cfg::new(
+        h,
         vec![
             (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
             (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),

--- a/src/actions/tap_hold.rs
+++ b/src/actions/tap_hold.rs
@@ -325,9 +325,10 @@ fn test_tap() {
     let cfg = Cfg::new(
         HashMap::new(),
         vec![
-            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
-            (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
-        ],
+            vec![
+                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
+                (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
+            ],
     ]);
 
     let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
@@ -392,12 +393,13 @@ fn test_hold() {
     let cfg = Cfg::new(
         h,
         vec![
-            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
-            (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
-        ],
+            vec![
+                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
+                (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
+            ],
     ]);
 
-    let mut l_mgr = LayersManager::new(&cfg.layers);
+    let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);
 
     l_mgr.init();

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,11 +1,11 @@
 use crate::layers::Layers;
 
 #[cfg(test)]
+use crate::actions::Action;
+#[cfg(test)]
 use crate::keys::KeyCode;
 #[cfg(test)]
 use crate::layers::Layer;
-#[cfg(test)]
-use crate::actions::Action;
 
 use ron::de;
 use serde::Deserialize;

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -9,6 +9,7 @@ use crate::actions::Action;
 
 use ron::de;
 use serde::Deserialize;
+use std::collections::HashMap;
 
 // ------------------- Cfg ---------------------
 
@@ -18,21 +19,39 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 pub struct Cfg {
     pub layers: Layers,
+    pub layer_aliases: HashMap<usize, Option<String>>,
+    pub tap_hold_wait_time: u64,
+    pub tap_dance_wait_time: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PreCfg {
+    pub layers: Layers,
+    pub layer_aliases: HashMap<usize, String>,
     pub tap_hold_wait_time: u64,
     pub tap_dance_wait_time: u64,
 }
 
 impl Cfg {
     #[cfg(test)]
-    pub fn new(layers: Vec<Vec<(KeyCode, Action)>>) -> Self {
+    pub fn new(aliases: HashMap<usize, String>, layers: Vec<Vec<(KeyCode, Action)>>) -> Self {
         let mut converted: Vec<Layer> = vec![];
-        for layer_vec in layers {
-            converted.push(layer_vec.into_iter().collect::<Layer>());
+        let mut layer_aliases: HashMap<usize, Option<String>> =
+            HashMap::with_capacity(layers.len());
+        for i in 0..layers.len() {
+            if let Some(alias) = aliases.get(&i) {
+                layer_aliases.insert(i, Some(alias.clone()));
+            } else {
+                layer_aliases.insert(i, None);
+            }
+            converted.push(layers[i].clone().into_iter().collect::<Layer>());
         }
 
-        Self{layers: converted,
-             tap_hold_wait_time: 0,
-             tap_dance_wait_time: 0,
+        Self {
+            layers: converted,
+            layer_aliases,
+            tap_hold_wait_time: 0,
+            tap_dance_wait_time: 0,
         }
     }
 }
@@ -40,6 +59,19 @@ impl Cfg {
 // ------------------- Util Functions ---------------------
 
 pub fn parse(cfg: &String) -> Cfg {
-    de::from_str(cfg)
-        .expect("Failed to parse the config file")
+    let pre: PreCfg = de::from_str(cfg).expect("Failed to parse the config file");
+    let mut aliases = HashMap::new();
+    for i in 0..pre.layers.len() {
+        if let Some(alias) = pre.layer_aliases.get(&i) {
+            aliases.insert(i, Some(alias.clone()));
+        } else {
+            aliases.insert(i, None);
+        }
+    }
+    Cfg {
+        layers: pre.layers,
+        layer_aliases: aliases,
+        tap_hold_wait_time: pre.tap_hold_wait_time,
+        tap_dance_wait_time: pre.tap_dance_wait_time,
+    }
 }

--- a/src/effects/dj.rs
+++ b/src/effects/dj.rs
@@ -1,12 +1,12 @@
 use serde::Deserialize;
 
+use enum_iterator::IntoEnumIterator;
+use std::collections::HashMap;
+use std::fs::File;
 use std::io;
 use std::io::Read;
 use std::path::Path;
 use std::sync::Arc;
-use std::fs::File;
-use std::collections::HashMap;
-use enum_iterator::IntoEnumIterator;
 
 use rodio;
 use rodio::Source;
@@ -14,7 +14,7 @@ use std::convert::AsRef;
 
 //---------------------------------------------------
 
-struct SoundImpl (Arc<Vec<u8>>);
+struct SoundImpl(Arc<Vec<u8>>);
 
 impl AsRef<[u8]> for SoundImpl {
     fn as_ref(&self) -> &[u8] {
@@ -76,10 +76,13 @@ impl Dj {
     }
 
     pub fn new(assets_path: &Path) -> Self {
-        let dev = rodio::default_output_device()
-            .expect("Failed to open the default sound device");
+        let dev = rodio::default_output_device().expect("Failed to open the default sound device");
         let ksnds = Self::make_ksnds(assets_path);
-        Self{dev, ksnds, custom_snds: HashMap::new()}
+        Self {
+            dev,
+            ksnds,
+            custom_snds: HashMap::new(),
+        }
     }
 
     pub fn play(&self, snd: KSnd) {
@@ -90,7 +93,8 @@ impl Dj {
     pub fn play_custom(&mut self, path: &String) {
         if !self.custom_snds.contains_key(path) {
             let _path = Path::new(path);
-            self.custom_snds.insert(path.clone(), SoundImpl::load(&_path).unwrap());
+            self.custom_snds
+                .insert(path.clone(), SoundImpl::load(&_path).unwrap());
         }
 
         let snd = &self.custom_snds[path];

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -1,18 +1,18 @@
-mod sticky;
 mod dj;
+mod sticky;
 
 pub mod perform;
+pub use dj::Dj;
+pub use dj::KSnd;
 pub use perform::perform_effect;
 pub use sticky::StickyState;
-pub use dj::KSnd;
-pub use dj::Dj;
 
-use crate::keys::KeyValue;
+use crate::actions::Action;
 use crate::keys::KeyCode;
 use crate::keys::KeyEvent;
+use crate::keys::KeyValue;
 use crate::layers::LayerIndex;
 use crate::layers::LayersManager;
-use crate::actions::Action;
 use inner::inner;
 use serde::Deserialize;
 
@@ -24,7 +24,7 @@ pub enum Effect {
     KeySticky(KeyCode),
     KeySeq(Vec<KeyCode>),
 
-    Meh, // Ctrl+Alt+Shift
+    Meh,   // Ctrl+Alt+Shift
     Hyper, // Ctrl+Alt+Shift+Win
 
     ToggleLayerAlias(String),
@@ -35,7 +35,6 @@ pub enum Effect {
     SoundEx(String),
 
     Multi(Vec<Effect>),
-
     // Not Implemented Yet
     // ---------------------
     // OneShotLayer(LayerIndex),
@@ -47,7 +46,7 @@ pub fn key_event_to_fx_val(l_mgr: &LayersManager, event: &KeyEvent) -> EffectVal
     let merged = l_mgr.get(event.code);
     let effect = inner!(&merged.action, if Action::Tap).clone();
 
-    EffectValue{
+    EffectValue {
         fx: effect,
         val: event.value.into(),
     }
@@ -66,7 +65,7 @@ pub struct EffectValue {
 
 impl EffectValue {
     pub fn new(fx: Effect, val: KeyValue) -> Self {
-        Self{fx, val}
+        Self { fx, val }
     }
 }
 
@@ -80,14 +79,14 @@ impl OutEffects {
     pub fn new(stop_processing: bool, effect: Effect, value: KeyValue) -> Self {
         OutEffects {
             stop_processing,
-            effects: Some(vec![EffectValue::new(effect, value)])
+            effects: Some(vec![EffectValue::new(effect, value)]),
         }
     }
 
     pub fn new_multiple(stop_processing: bool, effects: Vec<EffectValue>) -> Self {
         OutEffects {
             stop_processing,
-            effects: Some(effects)
+            effects: Some(effects),
         }
     }
 

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -27,6 +27,7 @@ pub enum Effect {
     Meh, // Ctrl+Alt+Shift
     Hyper, // Ctrl+Alt+Shift+Win
 
+    ToggleLayerAlias(String),
     ToggleLayer(LayerIndex),
     MomentaryLayer(LayerIndex),
 

--- a/src/effects/perform.rs
+++ b/src/effects/perform.rs
@@ -1,12 +1,12 @@
-use crate::keys::KeyCode;
-use crate::keys::KeyCode::*;
-use crate::keys::KeyValue;
 use crate::effects::Effect;
 use crate::effects::EffectValue;
 use crate::effects::KSnd;
 use crate::kbd_out::KbdOut;
-use crate::layers::LayerIndex;
+use crate::keys::KeyCode;
+use crate::keys::KeyCode::*;
+use crate::keys::KeyValue;
 use crate::ktrl::Ktrl;
+use crate::layers::LayerIndex;
 
 use std::io::Error;
 use std::vec::Vec;
@@ -31,7 +31,11 @@ lazy_static::lazy_static! {
     };
 }
 
-fn perform_multiple_effects(ktrl: &mut Ktrl, effects: Vec<Effect>, value: KeyValue) -> Result<(), Error> {
+fn perform_multiple_effects(
+    ktrl: &mut Ktrl,
+    effects: Vec<Effect>,
+    value: KeyValue,
+) -> Result<(), Error> {
     for fx in effects {
         let sub_fx_val = EffectValue::new(fx.clone(), value);
         perform_effect(ktrl, sub_fx_val)?;
@@ -40,8 +44,11 @@ fn perform_multiple_effects(ktrl: &mut Ktrl, effects: Vec<Effect>, value: KeyVal
     Ok(())
 }
 
-
-fn perform_play_custom_sound(ktrl: &mut Ktrl, snd_path: String , value: KeyValue) -> Result<(), Error> {
+fn perform_play_custom_sound(
+    ktrl: &mut Ktrl,
+    snd_path: String,
+    value: KeyValue,
+) -> Result<(), Error> {
     if value == KeyValue::Press {
         ktrl.dj.play_custom(&snd_path)
     }

--- a/src/effects/perform.rs
+++ b/src/effects/perform.rs
@@ -75,6 +75,14 @@ fn perform_toggle_layer(ktrl: &mut Ktrl, idx: LayerIndex, value: KeyValue) -> Re
     Ok(())
 }
 
+fn perform_toggle_layer_alias(ktrl: &mut Ktrl, name: String, value: KeyValue) -> Result<(), Error> {
+    if value == KeyValue::Press {
+        ktrl.l_mgr.toggle_layer_alias(name)
+    }
+
+    Ok(())
+}
+
 fn perform_key_sticky(ktrl: &mut Ktrl, code: KeyCode, value: KeyValue) -> Result<(), Error> {
     if value == KeyValue::Release {
         return Ok(());
@@ -110,6 +118,7 @@ pub fn perform_effect(ktrl: &mut Ktrl, fx_val: EffectValue) -> Result<(), Error>
         Effect::Meh => perform_keyseq(&mut ktrl.kbd_out, MEH.to_vec(), fx_val.val),
         Effect::Hyper => perform_keyseq(&mut ktrl.kbd_out, HYPER.to_vec(), fx_val.val),
         Effect::ToggleLayer(idx) => perform_toggle_layer(ktrl, idx, fx_val.val),
+        Effect::ToggleLayerAlias(name) => perform_toggle_layer_alias(ktrl, name, fx_val.val),
         Effect::MomentaryLayer(idx) => perform_momentary_layer(ktrl, idx, fx_val.val),
         Effect::Sound(snd) => perform_play_sound(ktrl, snd, fx_val.val),
         Effect::SoundEx(snd) => perform_play_custom_sound(ktrl, snd, fx_val.val),

--- a/src/effects/sticky.rs
+++ b/src/effects/sticky.rs
@@ -1,16 +1,18 @@
-use std::collections::HashSet;
 use crate::keys::KeyCode;
-use crate::layers::LockOwner::LkSticky;
 use crate::layers::LayersManager;
+use crate::layers::LockOwner::LkSticky;
 use log::debug;
+use std::collections::HashSet;
 
 pub struct StickyState {
-    pressed: HashSet<KeyCode>
+    pressed: HashSet<KeyCode>,
 }
 
 impl StickyState {
     pub fn new() -> Self {
-        Self{pressed: HashSet::new()}
+        Self {
+            pressed: HashSet::new(),
+        }
     }
 
     pub fn update_pressed(&mut self, l_mgr: &mut LayersManager, key: KeyCode) {

--- a/src/kbd_in.rs
+++ b/src/kbd_in.rs
@@ -1,9 +1,9 @@
 // evdev-rs
 use evdev_rs::Device;
 use evdev_rs::GrabMode;
+use evdev_rs::InputEvent;
 use evdev_rs::ReadFlag;
 use evdev_rs::ReadStatus;
-use evdev_rs::InputEvent;
 
 use std::fs::File;
 use std::path::Path;
@@ -17,11 +17,13 @@ impl KbdIn {
         let kbd_in_file = File::open(dev_path)?;
         let mut kbd_in_dev = Device::new_from_fd(kbd_in_file)?;
         kbd_in_dev.grab(GrabMode::Grab)?;
-        Ok(KbdIn {device: kbd_in_dev})
+        Ok(KbdIn { device: kbd_in_dev })
     }
 
     pub fn read(&self) -> Result<InputEvent, std::io::Error> {
-        let (status, event) = self.device.next_event(ReadFlag::NORMAL | ReadFlag::BLOCKING)?;
+        let (status, event) = self
+            .device
+            .next_event(ReadFlag::NORMAL | ReadFlag::BLOCKING)?;
         std::assert!(status == ReadStatus::Success);
         Ok(event)
     }

--- a/src/kbd_out.rs
+++ b/src/kbd_out.rs
@@ -2,24 +2,24 @@
 use uinput_sys;
 use uinput_sys::uinput_user_dev;
 
-use evdev_rs::TimeVal;
-use evdev_rs::InputEvent;
-use evdev_rs::enums::EventCode;
 use crate::keys::KeyCode;
 use crate::keys::KeyValue;
+use evdev_rs::enums::EventCode;
 use evdev_rs::enums::EV_SYN;
+use evdev_rs::InputEvent;
+use evdev_rs::TimeVal;
 use libc::input_event as raw_event;
 
 // file i/o
-use std::fs::OpenOptions;
-use std::fs::File;
-use std::os::unix::io::AsRawFd;
-use std::io;
 use io::Write;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io;
+use std::os::unix::io::AsRawFd;
 
 // unsafe
-use std::slice;
 use std::mem;
+use std::slice;
 
 // ktrl
 use crate::keys::KeyEvent;
@@ -30,7 +30,10 @@ pub struct KbdOut {
 
 impl KbdOut {
     pub fn new() -> Result<Self, io::Error> {
-        let mut uinput_out_file = OpenOptions::new().read(true).write(true).open("/dev/uinput")?;
+        let mut uinput_out_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open("/dev/uinput")?;
 
         unsafe {
             uinput_sys::ui_set_evbit(uinput_out_file.as_raw_fd(), uinput_sys::EV_SYN);
@@ -46,37 +49,47 @@ impl KbdOut {
             uidev.name[2] = 'r' as i8;
             uidev.name[3] = 'l' as i8;
             uidev.id.bustype = 0x3; // BUS_USB
-            uidev.id.vendor  = 0x1;
+            uidev.id.vendor = 0x1;
             uidev.id.product = 0x1;
             uidev.id.version = 1;
 
-            let uidev_bytes = slice::from_raw_parts(mem::transmute(&uidev),
-                                                    mem::size_of::<uinput_user_dev>());
+            let uidev_bytes =
+                slice::from_raw_parts(mem::transmute(&uidev), mem::size_of::<uinput_user_dev>());
             uinput_out_file.write(uidev_bytes)?;
             uinput_sys::ui_dev_create(uinput_out_file.as_raw_fd());
         }
 
-        Ok(KbdOut{device: uinput_out_file})
+        Ok(KbdOut {
+            device: uinput_out_file,
+        })
     }
 
     pub fn write(&mut self, event: InputEvent) -> Result<(), io::Error> {
         let ev = event.as_raw();
 
         unsafe {
-            let ev_bytes = slice::from_raw_parts(mem::transmute(&ev as *const raw_event),
-                                                 mem::size_of::<raw_event>());
+            let ev_bytes = slice::from_raw_parts(
+                mem::transmute(&ev as *const raw_event),
+                mem::size_of::<raw_event>(),
+            );
             self.device.write(ev_bytes)?;
         };
 
         Ok(())
     }
 
-
     pub fn write_key(&mut self, key: KeyCode, value: KeyValue) -> Result<(), io::Error> {
         let key_ev = KeyEvent::new(key, value);
         self.write(key_ev.into())?;
 
-        let sync = InputEvent::new(&TimeVal{tv_sec: 0, tv_usec:0}, &EventCode::EV_SYN(EV_SYN::SYN_REPORT), 0);
+        let sync = InputEvent::new(
+            &TimeVal {
+                tv_sec: 0,
+                tv_usec: 0,
+            },
+            &EventCode::EV_SYN(EV_SYN::SYN_REPORT),
+            0,
+        );
         self.write(sync.into())?;
 
         Ok(())

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,8 +1,8 @@
 // use std::fmt;
-use evdev_rs::enums::{EV_KEY, EventType, EventCode};
+use evdev_rs::enums::{EventCode, EventType, EV_KEY};
 use evdev_rs::{InputEvent, TimeVal};
-use std::convert::TryFrom;
 use serde::Deserialize;
+use std::convert::TryFrom;
 
 // ------------------ KeyCode --------------------
 
@@ -1111,7 +1111,7 @@ impl KeyCode {
             741 => Some(KeyCode::BTN_TRIGGER_HAPPY38),
             742 => Some(KeyCode::BTN_TRIGGER_HAPPY39),
             743 => Some(KeyCode::BTN_TRIGGER_HAPPY40),
-            _ => None
+            _ => None,
         }
     }
 }
@@ -1128,11 +1128,9 @@ impl TryFrom<usize> for KeyCode {
 
 impl From<u32> for KeyCode {
     fn from(item: u32) -> Self {
-        Self::from_u32(item)
-            .expect(&format!("Invalid KeyCode: {}", item))
+        Self::from_u32(item).expect(&format!("Invalid KeyCode: {}", item))
     }
 }
-
 
 impl From<KeyCode> for usize {
     fn from(item: KeyCode) -> Self {
@@ -1184,9 +1182,7 @@ impl From<i32> for KeyValue {
             0 => Self::Release,
             1 => Self::Press,
             2 => Self::Repeat,
-            _ => {
-                unreachable!()
-            }
+            _ => unreachable!(),
         }
     }
 }
@@ -1202,7 +1198,7 @@ pub struct KeyEvent {
 impl KeyEvent {
     pub fn new(code: KeyCode, value: KeyValue) -> Self {
         let time = TimeVal::new(0, 0);
-        Self{time, code, value}
+        Self { time, code, value }
     }
 
     #[cfg(test)]
@@ -1220,11 +1216,11 @@ impl TryFrom<InputEvent> for KeyEvent {
     type Error = ();
     fn try_from(item: InputEvent) -> Result<Self, Self::Error> {
         match &item.event_type {
-            EventType::EV_KEY => Ok(
-                Self{time: item.time,
-                     code: item.event_code.into(),
-                     value: item.value.into()}
-            ),
+            EventType::EV_KEY => Ok(Self {
+                time: item.time,
+                code: item.event_code.into(),
+                value: item.value.into(),
+            }),
             _ => Err(()),
         }
     }
@@ -1232,9 +1228,11 @@ impl TryFrom<InputEvent> for KeyEvent {
 
 impl From<KeyEvent> for InputEvent {
     fn from(item: KeyEvent) -> Self {
-        Self{time: item.time,
-             event_type: EventType::EV_KEY,
-             event_code: item.code.into(),
-             value: item.value as i32}
+        Self {
+            time: item.time,
+            event_type: EventType::EV_KEY,
+            event_code: item.code.into(),
+            value: item.value as i32,
+        }
     }
 }

--- a/src/ktrl.rs
+++ b/src/ktrl.rs
@@ -1,21 +1,21 @@
 use evdev_rs::enums::EventType;
-use log::{info, error};
+use log::{error, info};
 
 use std::convert::TryFrom;
-use std::path::PathBuf;
 use std::fs::read_to_string;
+use std::path::PathBuf;
 
-use crate::cfg;
-use crate::KbdIn;
-use crate::KbdOut;
-use crate::keys::KeyEvent;
-use crate::layers::LayersManager;
-use crate::actions::TapHoldMgr;
 use crate::actions::TapDanceMgr;
+use crate::actions::TapHoldMgr;
+use crate::cfg;
 use crate::effects::key_event_to_fx_val;
 use crate::effects::perform_effect;
-use crate::effects::StickyState;
 use crate::effects::Dj;
+use crate::effects::StickyState;
+use crate::keys::KeyEvent;
+use crate::layers::LayersManager;
+use crate::KbdIn;
+use crate::KbdOut;
 
 pub struct KtrlArgs {
     pub kbd_path: PathBuf,
@@ -61,7 +61,15 @@ impl Ktrl {
         let sticky = StickyState::new();
         let dj = Dj::new(&args.assets_path);
 
-        Ok(Self{kbd_in, kbd_out, l_mgr, th_mgr, td_mgr, sticky, dj})
+        Ok(Self {
+            kbd_in,
+            kbd_out,
+            l_mgr,
+            th_mgr,
+            td_mgr,
+            sticky,
+            dj,
+        })
     }
 
     //
@@ -107,15 +115,15 @@ impl Ktrl {
             let in_event = self.kbd_in.read()?;
 
             // Filter uninteresting events
-            if in_event.event_type == EventType::EV_SYN ||
-                in_event.event_type == EventType::EV_MSC {
+            if in_event.event_type == EventType::EV_SYN || in_event.event_type == EventType::EV_MSC
+            {
                 continue;
             }
 
             // Pass-through non-key events
             let key_event = match KeyEvent::try_from(in_event.clone()) {
                 Ok(ev) => ev,
-                _ =>  {
+                _ => {
                     self.kbd_out.write(in_event)?;
                     continue;
                 }

--- a/src/ktrl.rs
+++ b/src/ktrl.rs
@@ -53,7 +53,7 @@ impl Ktrl {
 
         let cfg_str = read_to_string(args.config_path)?;
         let cfg = cfg::parse(&cfg_str);
-        let mut l_mgr = LayersManager::new(&cfg.layers);
+        let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
         l_mgr.init();
 
         let th_mgr = TapHoldMgr::new(cfg.tap_hold_wait_time);

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -1,13 +1,13 @@
 use crate::keys::KeyCode::*;
-use std::vec::Vec;
+use log::{debug, warn};
 use std::collections::HashMap;
 use std::convert::TryFrom;
-use log::{warn, debug};
+use std::vec::Vec;
 
-use crate::keys::KeyCode;
-pub use crate::actions::Action;
 pub use crate::actions::tap_hold::TapHoldState;
+pub use crate::actions::Action;
 pub use crate::effects::Effect;
+use crate::keys::KeyCode;
 
 // -------------- Constants -------------
 
@@ -76,7 +76,11 @@ fn init_merged() -> Merged {
             let effect = Effect::Key(code);
             let action = Action::Tap(effect);
             let layer_index = 0;
-            merged.push(Some(MergedKey{code, action, layer_index}));
+            merged.push(Some(MergedKey {
+                code,
+                action,
+                layer_index,
+            }));
         } else {
             merged.push(None);
         }
@@ -144,14 +148,18 @@ impl LayersManager {
         self.turn_layer_on(0);
     }
 
-    fn is_overriding_key(&self, candidate_code: KeyCode, candidate_layer_index: LayerIndex) -> bool {
+    fn is_overriding_key(
+        &self,
+        candidate_code: KeyCode,
+        candidate_layer_index: LayerIndex,
+    ) -> bool {
         let current = self.get(candidate_code);
-        return candidate_layer_index >= current.layer_index
+        return candidate_layer_index >= current.layer_index;
     }
 
     fn get_replacement_merged_key(&self, layers: &Layers, removed_code: KeyCode) -> MergedKey {
         let current = self.get(removed_code);
-        let lower_layer_idx = current.layer_index-1;
+        let lower_layer_idx = current.layer_index - 1;
 
         for i in lower_layer_idx..=0 {
             let lower_layer = &layers[i];
@@ -160,26 +168,26 @@ impl LayersManager {
             }
 
             let lower_action = &layers[i][&removed_code];
-            let replacement = MergedKey{
+            let replacement = MergedKey {
                 code: removed_code,
                 action: lower_action.clone(),
-                layer_index: i
+                layer_index: i,
             };
 
             return replacement;
         }
 
-        MergedKey{
+        MergedKey {
             code: removed_code,
             action: Action::Tap(Effect::Key(removed_code)),
-            layer_index: 0
+            layer_index: 0,
         }
     }
 
     pub fn get(&self, key: KeyCode) -> &MergedKey {
         match &self.merged[usize::from(key)] {
             Some(merged_key) => merged_key,
-            _ => panic!("Invalid KeyCode")
+            _ => panic!("Invalid KeyCode"),
         }
     }
 
@@ -196,7 +204,10 @@ impl LayersManager {
 
     fn is_layer_change_safe(&self, index: LayerIndex, layer: &Layer) -> bool {
         if self.is_all_locked() {
-            warn!("Can't turn layer {} on. You're currently using a blocking action/effect", index);
+            warn!(
+                "Can't turn layer {} on. You're currently using a blocking action/effect",
+                index
+            );
             return false;
         }
 
@@ -212,7 +223,7 @@ impl LayersManager {
         std::assert!(!self.layers_states[index]);
         let layer = &self.layers[index];
 
-        if !self.is_layer_change_safe(index, layer){
+        if !self.is_layer_change_safe(index, layer) {
             return;
         }
 
@@ -220,10 +231,10 @@ impl LayersManager {
             let is_overriding = self.is_overriding_key(*code, index);
 
             if is_overriding {
-                let new_entry = MergedKey{
+                let new_entry = MergedKey {
                     code: *code,
                     action: action.clone(),
-                    layer_index: index
+                    layer_index: index,
                 };
 
                 self.merged[usize::from(*code)] = Some(new_entry);
@@ -239,7 +250,7 @@ impl LayersManager {
         std::assert!(self.layers_states[index]);
 
         let layer = &self.layers[index];
-        if !self.is_layer_change_safe(index, layer){
+        if !self.is_layer_change_safe(index, layer) {
             return;
         }
 
@@ -348,7 +359,6 @@ fn test_mgr() {
                 (KEY_LEFTCTRL, Tap(Key(KEY_CAPSLOCK))),
                 (KEY_CAPSLOCK, Tap(Key(KEY_LEFTCTRL))),
             ],
-
             // 1: arrows layer
             vec![
                 // Ex: switch CTRL <--> Capslock
@@ -357,7 +367,6 @@ fn test_mgr() {
                 (KEY_K, Tap(Key(KEY_UP))),
                 (KEY_L, Tap(Key(KEY_RIGHT))),
             ],
-
             // 2: asdf modifiers
             vec![
                 // Ex: switch CTRL <--> Capslock
@@ -365,7 +374,8 @@ fn test_mgr() {
                 (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTSHIFT))),
                 (KEY_D, TapHold(Key(KEY_D), Key(KEY_LEFTALT))),
             ],
-    ]);
+        ],
+    );
 
     let mut mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
     mgr.init();
@@ -378,9 +388,18 @@ fn test_mgr() {
     assert_eq!(mgr.get(KEY_K.into()).action, Tap(Key(KEY_K)));
     assert_eq!(mgr.get(KEY_L.into()).action, Tap(Key(KEY_L)));
 
-    assert_eq!(mgr.get(KEY_A.into()).action, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL)));
-    assert_eq!(mgr.get(KEY_S.into()).action, TapHold(Key(KEY_S), Key(KEY_LEFTSHIFT)));
-    assert_eq!(mgr.get(KEY_D.into()).action, TapHold(Key(KEY_D), Key(KEY_LEFTALT)));
+    assert_eq!(
+        mgr.get(KEY_A.into()).action,
+        TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))
+    );
+    assert_eq!(
+        mgr.get(KEY_S.into()).action,
+        TapHold(Key(KEY_S), Key(KEY_LEFTSHIFT))
+    );
+    assert_eq!(
+        mgr.get(KEY_D.into()).action,
+        TapHold(Key(KEY_D), Key(KEY_LEFTALT))
+    );
 
     mgr.turn_layer_on(1);
     assert_eq!(mgr.get(KEY_H.into()).action, Tap(Key(KEY_LEFT)));
@@ -388,9 +407,18 @@ fn test_mgr() {
     assert_eq!(mgr.get(KEY_K.into()).action, Tap(Key(KEY_UP)));
     assert_eq!(mgr.get(KEY_L.into()).action, Tap(Key(KEY_RIGHT)));
 
-    assert_eq!(mgr.get(KEY_A.into()).action, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL)));
-    assert_eq!(mgr.get(KEY_S.into()).action, TapHold(Key(KEY_S), Key(KEY_LEFTSHIFT)));
-    assert_eq!(mgr.get(KEY_D.into()).action, TapHold(Key(KEY_D), Key(KEY_LEFTALT)));
+    assert_eq!(
+        mgr.get(KEY_A.into()).action,
+        TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))
+    );
+    assert_eq!(
+        mgr.get(KEY_S.into()).action,
+        TapHold(Key(KEY_S), Key(KEY_LEFTSHIFT))
+    );
+    assert_eq!(
+        mgr.get(KEY_D.into()).action,
+        TapHold(Key(KEY_D), Key(KEY_LEFTALT))
+    );
 
     mgr.turn_layer_off(2);
     assert_eq!(mgr.get(KEY_H.into()).action, Tap(Key(KEY_LEFT)));
@@ -432,7 +460,6 @@ fn test_mgr() {
 
 #[test]
 fn test_overlapping_keys() {
-
     let mut h = HashMap::new();
     h.insert(0, "base".to_string());
     h.insert(1, "arrows".to_string());
@@ -440,15 +467,10 @@ fn test_overlapping_keys() {
         h,
         vec![
             // 0: base layer
-            vec![
-                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))),
-            ],
-
+            vec![(KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT)))],
             // 1: arrows layer
             // Ex: switch CTRL <--> Capslock
-            vec![
-                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))),
-            ]
+            vec![(KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT)))],
         ],
     );
 
@@ -456,9 +478,18 @@ fn test_overlapping_keys() {
     mgr.init();
 
     assert_eq!(mgr.layers_states.len(), 2);
-    assert_eq!(mgr.get(KEY_A.into()).action, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT)));
+    assert_eq!(
+        mgr.get(KEY_A.into()).action,
+        TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))
+    );
     mgr.turn_layer_on(1);
-    assert_eq!(mgr.get(KEY_A.into()).action, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT)));
+    assert_eq!(
+        mgr.get(KEY_A.into()).action,
+        TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))
+    );
     mgr.turn_layer_off(1);
-    assert_eq!(mgr.get(KEY_A.into()).action, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT)));
+    assert_eq!(
+        mgr.get(KEY_A.into()).action,
+        TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))
+    );
 }

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -343,27 +343,28 @@ fn test_mgr() {
     let cfg = Cfg::new(
         h,
         vec![
-            // Ex: switch CTRL <--> Capslock
-            (KEY_LEFTCTRL, Tap(Key(KEY_CAPSLOCK))),
-            (KEY_CAPSLOCK, Tap(Key(KEY_LEFTCTRL))),
-        ],
+            vec![
+                // Ex: switch CTRL <--> Capslock
+                (KEY_LEFTCTRL, Tap(Key(KEY_CAPSLOCK))),
+                (KEY_CAPSLOCK, Tap(Key(KEY_LEFTCTRL))),
+            ],
 
-        // 1: arrows layer
-        vec![
-            // Ex: switch CTRL <--> Capslock
-            (KEY_H, Tap(Key(KEY_LEFT))),
-            (KEY_J, Tap(Key(KEY_DOWN))),
-            (KEY_K, Tap(Key(KEY_UP))),
-            (KEY_L, Tap(Key(KEY_RIGHT))),
-        ],
+            // 1: arrows layer
+            vec![
+                // Ex: switch CTRL <--> Capslock
+                (KEY_H, Tap(Key(KEY_LEFT))),
+                (KEY_J, Tap(Key(KEY_DOWN))),
+                (KEY_K, Tap(Key(KEY_UP))),
+                (KEY_L, Tap(Key(KEY_RIGHT))),
+            ],
 
-        // 2: asdf modifiers
-        vec![
-            // Ex: switch CTRL <--> Capslock
-            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
-            (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTSHIFT))),
-            (KEY_D, TapHold(Key(KEY_D), Key(KEY_LEFTALT))),
-        ],
+            // 2: asdf modifiers
+            vec![
+                // Ex: switch CTRL <--> Capslock
+                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
+                (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTSHIFT))),
+                (KEY_D, TapHold(Key(KEY_D), Key(KEY_LEFTALT))),
+            ],
     ]);
 
     let mut mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
@@ -431,22 +432,25 @@ fn test_mgr() {
 
 #[test]
 fn test_overlapping_keys() {
-        // 0: base layer
-        vec![
-            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))),
-        ],
 
-        // 1: arrows layer
     let mut h = HashMap::new();
     h.insert(0, "base".to_string());
     h.insert(1, "arrows".to_string());
     let cfg = Cfg::new(
         h,
         vec![
+            // 0: base layer
+            vec![
+                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))),
+            ],
+
+            // 1: arrows layer
             // Ex: switch CTRL <--> Capslock
-            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))),
+            vec![
+                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))),
+            ]
         ],
-    ]);
+    );
 
     let mut mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
     mgr.init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,18 +1,18 @@
-use std::path::Path;
+use clap::{App, Arg};
 use log::info;
 use simplelog::*;
-use clap::{App, Arg};
-use std::io::{Error, ErrorKind::*};
 use std::fs::File;
+use std::io::{Error, ErrorKind::*};
+use std::path::Path;
 
+mod actions;
+mod cfg;
+mod effects;
 mod kbd_in;
 mod kbd_out;
+mod keys;
 mod ktrl;
 mod layers;
-mod keys;
-mod actions;
-mod effects;
-mod cfg;
 
 use kbd_in::KbdIn;
 use kbd_out::KbdOut;
@@ -25,36 +25,54 @@ const DEFAULT_ASSETS_PATH: &str = "/opt/ktrl/assets";
 
 #[doc(hidden)]
 fn cli_init() -> Result<KtrlArgs, std::io::Error> {
-    let matches =
-        App::new("ktrl")
+    let matches = App::new("ktrl")
         .version("0.1")
         .author("Itay G. <thifixp@gmail.com>")
         .about("Unleashes your keyboard's full potential")
-        .arg(Arg::with_name("device")
-             .short("d")
-             .long("device")
-             .value_name("DEVICE")
-             .help("Path to your keyboard's input device. Usually in /dev/input/")
-             .takes_value(true)
-             .required(true))
-        .arg(Arg::with_name("cfg")
-             .long("cfg")
-             .value_name("CONFIG")
-             .help(&format!("Path to your ktrl config file. Default: {}", DEFAULT_CFG_PATH))
-             .takes_value(true))
-        .arg(Arg::with_name("assets")
-             .long("assets")
-             .value_name("ASSETS")
-             .help(&format!("Path ktrl's assets directory. Default: {}", DEFAULT_ASSETS_PATH))
-             .takes_value(true))
-        .arg(Arg::with_name("logfile")
-             .long("log")
-             .value_name("LOGFILE")
-             .help(&format!("Path to the log file. Default: {}", DEFAULT_LOG_PATH))
-             .takes_value(true))
-        .arg(Arg::with_name("debug")
-             .long("debug")
-             .help("Enables debug level logging"))
+        .arg(
+            Arg::with_name("device")
+                .short("d")
+                .long("device")
+                .value_name("DEVICE")
+                .help("Path to your keyboard's input device. Usually in /dev/input/")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("cfg")
+                .long("cfg")
+                .value_name("CONFIG")
+                .help(&format!(
+                    "Path to your ktrl config file. Default: {}",
+                    DEFAULT_CFG_PATH
+                ))
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("assets")
+                .long("assets")
+                .value_name("ASSETS")
+                .help(&format!(
+                    "Path ktrl's assets directory. Default: {}",
+                    DEFAULT_ASSETS_PATH
+                ))
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("logfile")
+                .long("log")
+                .value_name("LOGFILE")
+                .help(&format!(
+                    "Path to the log file. Default: {}",
+                    DEFAULT_LOG_PATH
+                ))
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("debug")
+                .long("debug")
+                .help("Enables debug level logging"),
+        )
         .get_matches();
 
     let config_path = Path::new(matches.value_of("cfg").unwrap_or(DEFAULT_CFG_PATH));
@@ -67,27 +85,33 @@ fn cli_init() -> Result<KtrlArgs, std::io::Error> {
         _ => LevelFilter::Info,
     };
 
-    CombinedLogger::init(
-        vec![
-            TermLogger::new(log_lvl, Config::default(), TerminalMode::Mixed),
-            WriteLogger::new(log_lvl, Config::default(), File::create(log_path)
-                             .expect("Couldn't initialize the file logger")),
-        ]
-    ).expect("Couldn't initialize the logger");
+    CombinedLogger::init(vec![
+        TermLogger::new(log_lvl, Config::default(), TerminalMode::Mixed),
+        WriteLogger::new(
+            log_lvl,
+            Config::default(),
+            File::create(log_path).expect("Couldn't initialize the file logger"),
+        ),
+    ])
+    .expect("Couldn't initialize the logger");
 
     if !config_path.exists() {
-        let err =  format!("Could not find your config file ({})",
-                           config_path.to_str().unwrap_or("?"));
+        let err = format!(
+            "Could not find your config file ({})",
+            config_path.to_str().unwrap_or("?")
+        );
         return Err(Error::new(NotFound, err));
     }
 
     if !kbd_path.exists() {
-        let err =  format!("Could not find the keyboard device ({})",
-                           kbd_path.to_str().unwrap_or("?"));
+        let err = format!(
+            "Could not find the keyboard device ({})",
+            kbd_path.to_str().unwrap_or("?")
+        );
         return Err(Error::new(NotFound, err));
     }
 
-    Ok(KtrlArgs{
+    Ok(KtrlArgs {
         kbd_path: kbd_path.to_path_buf(),
         config_path: config_path.to_path_buf(),
         assets_path: assets_path.to_path_buf(),


### PR DESCRIPTION
Ran `cargo fmt` for consistent formatting across the project. If you're against using this, no problem, but might be nice.

Note: ran this after adding named layer support, so might make sense to merge that prior to this