### PR TITLE
Profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ E.g Playing a sound, toggling a layer, sending a key sequence, etc...
 - `KeySeq`: Outputs multiple keys at once. E.g `Meh` and `Hyper` are `KeySeq`s
 - `Meh`: A shorthand for `KeySeq(KEY_LEFTCTRL, KEY_LEFTALT, KEY_LEFTSHIFT)`
 - `Hyper`: A shorthand for `KeySeq(KEY_LEFTCTRL, KEY_LEFTALT, KEY_LEFTSHIFT, KEY_LEFTMETA)`
+- `ActivateProfile`: Activates a user-defined profile
+- `DeactivateProfile`: Deactivates a user-defined profile
+- `DeactivateAllProfiles`: Deactivates all user-defined profiles
 - `ToggleLayerAlias`: When pressed, either turns on or off a named layer.
 - `ToggleLayer`: When pressed, either turns on or off a layer.
 - `MomentaryLayer`: While pressed, the relevant layer will remain active

--- a/examples/cfg.ron
+++ b/examples/cfg.ron
@@ -23,6 +23,21 @@
         "i_is_enter": 4,
     },
 
+    layer_profiles: {
+        "firefox": Profile(
+            on_indices: [],
+            off_indices: [],
+            on_aliases: ["h_is_enter", "i_is_enter"],
+            off_aliases: ["f_is_enter", "g_is_enter"],
+        ),
+        "not-firefox": Profile(
+            on_indices: [],
+            off_indices: [],
+            on_aliases: ["f_is_enter", "g_is_enter"],
+            off_aliases: ["h_is_enter", "i_is_enter"],
+        ),
+    },
+
     layers: [
         // Layer 0 (Base Layer)
         //
@@ -40,42 +55,13 @@
             KEY_CAPSLOCK:  Tap(Key(KEY_LEFTCTRL)),
             KEY_LEFTCTRL:  Tap(Key(KEY_LEFTCTRL)),
 
-            // F1 on regular tap, layer toggle on hold.
-            // A toggled layer will stay active until toggled again.
-            KEY_F1:  TapHold(Key(KEY_F1), ToggleLayerAlias("f_is_enter")),
-
-            // F2 on regular tap, layer toggle by index otherwise.
-            KEY_F2:  TapHold(Key(KEY_F2), ToggleLayer(2)),
-
-            // F2 on regular tap, layer toggle by index otherwise.
-            KEY_F3:  TapHold(Key(KEY_F3), ToggleLayerAlias("h_is_enter")),
-
-            // F4 on regular tap, layer toggle by index otherwise.
-            KEY_F4:  TapHold(Key(KEY_F4), ToggleLayerAlias("i_is_enter")),
+            KEY_F1:  TapHold(Key(KEY_F1), Multi([DeactivateProfile("not-firefox"), ActivateProfile("firefox")])),
+            KEY_F2:  TapHold(Key(KEY_F2), Multi([DeactivateProfile("firefox"), ActivateProfile("not-firefox")])),
+            KEY_F3:  TapHold(Key(KEY_F3), DeactivateAllProfiles),
         },
         // Layer 1
         {
-            // These two entries are to illustrate layer "priorities".
-            // Higher layers take precedence over lower layers.
-            //
-            // E.g these two entries will override the two lower entries.
-            // Thereby, restoring the swap we did over there.
-            //
-            KEY_CAPSLOCK:  Tap(Key(KEY_CAPSLOCK)),
-            KEY_LEFTCTRL:  Tap(Key(KEY_LEFTCTRL)),
-
-            // Press once for Enter, press 2 time for Sticky Shift.
-            // Sticky keys will remain active until pressed again.
             KEY_F:   TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
-
-            // Press once for D, press 3 to toggle this layer
-            KEY_D:   TapDance(3, Key(KEY_D), ToggleLayer(1)),
-
-            // Map Alt to Ctrl-Alt-Shift
-            KEY_LEFTALT:  Tap(Meh),
-
-            // Map Shift to Ctrl-Alt-Shift-Win
-            KEY_LEFTSHIFT: Tap(Hyper),
         },
         // Layer 2
         {

--- a/examples/cfg.ron
+++ b/examples/cfg.ron
@@ -17,24 +17,23 @@
     // Gives names to layers
     layer_aliases: {
         "base": 0,
-        "f_is_enter": 1,
-        "g_is_enter": 2,
-        "h_is_enter": 3,
-        "i_is_enter": 4,
+        "function_keys": 1,
+        "meta-disabled": 2,
+        "meta-enabled": 3,
     },
 
     layer_profiles: {
-        "firefox": Profile(
-            on_indices: [],
-            off_indices: [],
-            on_aliases: ["h_is_enter", "i_is_enter"],
-            off_aliases: ["f_is_enter", "g_is_enter"],
+        "function": Profile(
+            indices: [],
+            aliases: ["function_keys"],
         ),
-        "not-firefox": Profile(
-            on_indices: [],
-            off_indices: [],
-            on_aliases: ["f_is_enter", "g_is_enter"],
-            off_aliases: ["h_is_enter", "i_is_enter"],
+        "meta": Profile(
+            indices: [],
+            aliases: ["meta-enabled", "function_keys"]
+        ),
+        "no-meta": Profile(
+            indices: [],
+            aliases: ["meta-disabled"],
         ),
     },
 
@@ -52,30 +51,37 @@
         {
             // These two lines swap Capslock and Left-Ctrl.
             // As a bonus, an error sound will be played when you press Left-Ctrl
-            KEY_CAPSLOCK:  Tap(Key(KEY_LEFTCTRL)),
-            KEY_LEFTCTRL:  Tap(Key(KEY_LEFTCTRL)),
-
-            KEY_F1:  TapHold(Key(KEY_F1), Multi([DeactivateProfile("not-firefox"), ActivateProfile("firefox")])),
-            KEY_F2:  TapHold(Key(KEY_F2), Multi([DeactivateProfile("firefox"), ActivateProfile("not-firefox")])),
+            KEY_LEFTMETA:  Tap(Key(KEY_LEFTCTRL)),
+            KEY_RIGHTALT: TapHold(Key(KEY_RIGHTALT), ActivateProfile("meta")),
+            KEY_F1:  TapHold(Key(KEY_F1), ToggleLayerAlias("function_keys")),
             KEY_F3:  TapHold(Key(KEY_F3), DeactivateAllProfiles),
+
         },
-        // Layer 1
+        // function_keys
         {
-            KEY_F:   TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
+            // maps standard Mac keyboard to default to function keys.
+            KEY_BRIGHTNESSDOWN: Tap(Key(KEY_F1)), // 224
+            KEY_BRIGHTNESSUP: Tap(Key(KEY_F2)), // 225
+            KEY_SCALE: Tap(Key(KEY_F3)), // 120
+            KEY_DASHBOARD: Tap(Key(KEY_F4)), // 204
+            KEY_KBDILLUMDOWN: Tap(Key(KEY_F5)), //229
+            KEY_KBDILLUMUP: Tap(Key(KEY_F6)), // 230
+            KEY_PREVIOUSSONG: Tap(Key(KEY_F7)), // 165
+            KEY_PLAYPAUSE: Tap(Key(KEY_F8)), // 164
+            KEY_NEXTSONG: Tap(Key(KEY_F9)), // 163
+            KEY_MUTE: Tap(Key(KEY_F10)), // 113
+            KEY_VOLUMEDOWN: Tap(Key(KEY_F11)), // 114
+            KEY_VOLUMEUP: Tap(Key(KEY_F12)), // 115
         },
-        // Layer 2
+        // meta-disabled
         {
-            // Press once for enter, 2 times for sticky shift
-            KEY_G:   TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
+            KEY_LEFTMETA:  Tap(Key(KEY_LEFTCTRL)),
+            KEY_RIGHTALT: TapHold(Key(KEY_RIGHTALT), ActivateProfile("meta")),
         },
-        // Layer 3
+        // meta-enabled
         {
-            // Press once for enter, 2 times for sticky shift
-            KEY_H:   TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
+            KEY_LEFTMETA:  Tap(Key(KEY_LEFTMETA)),
+            KEY_RIGHTALT: TapHold(Key(KEY_RIGHTALT), ActivateProfile("no-meta")),
         },
-        // Layer 4
-        {
-            KEY_I: TapDance(2, Key(KEY_ENTER), KeySticky(KEY_LEFTSHIFT)),
-        }
     ],
 )

--- a/src/actions/tap_dance.rs
+++ b/src/actions/tap_dance.rs
@@ -280,11 +280,9 @@ fn test_tap_dance() {
     h.insert("base".to_string(), 0);
     let cfg = Cfg::new(
         h,
-        vec![
-            vec![
-                (KEY_A, TapDance(3, Key(KEY_A), Key(KEY_LEFTCTRL))),
-            ],
-    ], HashMap::new());
+        vec![vec![(KEY_A, TapDance(3, Key(KEY_A), Key(KEY_LEFTCTRL)))]],
+        HashMap::new(),
+    );
 
     let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases, &cfg.layer_profiles);
     let mut th_mgr = TapDanceMgr::new(500);

--- a/src/actions/tap_dance.rs
+++ b/src/actions/tap_dance.rs
@@ -284,9 +284,9 @@ fn test_tap_dance() {
             vec![
                 (KEY_A, TapDance(3, Key(KEY_A), Key(KEY_LEFTCTRL))),
             ],
-    ]);
+    ], HashMap::new());
 
-    let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
+    let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases, &cfg.layer_profiles);
     let mut th_mgr = TapDanceMgr::new(500);
 
     l_mgr.init();

--- a/src/actions/tap_hold.rs
+++ b/src/actions/tap_hold.rs
@@ -327,7 +327,7 @@ const TEST_TAP_HOLD_WAIT_PERIOD: u64 = 550;
 fn test_skipped() {
     use std::collections::HashMap;
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);
-    let mut l_mgr = LayersManager::new(&vec![], &HashMap::new());
+    let mut l_mgr = LayersManager::new(&vec![], &HashMap::new(), &HashMap::new());
     let ev_non_th_press = KeyEvent::new_press(KEY_A);
     let ev_non_th_release = KeyEvent::new_release(KEY_A);
     assert_eq!(
@@ -351,9 +351,9 @@ fn test_tap() {
                 (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
                 (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
             ],
-    ]);
+    ], HashMap::new());
 
-    let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
+    let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases, &cfg.layer_profiles);
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);
 
     l_mgr.init();
@@ -461,9 +461,9 @@ fn test_hold() {
                 (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
                 (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
             ],
-    ]);
+    ], HashMap::new());
 
-    let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
+    let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases, &cfg.layer_profiles);
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);
 
     l_mgr.init();

--- a/src/actions/tap_hold.rs
+++ b/src/actions/tap_hold.rs
@@ -346,12 +346,12 @@ fn test_tap() {
     use std::collections::HashMap;
     let cfg = Cfg::new(
         HashMap::new(),
-        vec![
-            vec![
-                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
-                (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
-            ],
-    ], HashMap::new());
+        vec![vec![
+            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
+            (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
+        ]],
+        HashMap::new(),
+    );
 
     let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases, &cfg.layer_profiles);
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);
@@ -456,12 +456,12 @@ fn test_hold() {
     h.insert("base".to_string(), 0);
     let cfg = Cfg::new(
         h,
-        vec![
-            vec![
-                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
-                (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
-            ],
-    ], HashMap::new());
+        vec![vec![
+            (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTCTRL))),
+            (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTALT))),
+        ]],
+        HashMap::new(),
+    );
 
     let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases, &cfg.layer_profiles);
     let mut th_mgr = TapHoldMgr::new(TEST_TAP_HOLD_WAIT_PERIOD);

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -1,5 +1,7 @@
 use crate::layers::Layers;
 
+use crate::layers::Profile;
+
 #[cfg(test)]
 use crate::actions::Action;
 #[cfg(test)]
@@ -20,13 +22,14 @@ use std::collections::HashMap;
 pub struct Cfg {
     pub layers: Layers,
     pub layer_aliases: HashMap<String, usize>,
+    pub layer_profiles: HashMap<String, Profile>,
     pub tap_hold_wait_time: u64,
     pub tap_dance_wait_time: u64,
 }
 
 impl Cfg {
     #[cfg(test)]
-    pub fn new(layer_aliases: HashMap<String, usize>, layers: Vec<Vec<(KeyCode, Action)>>) -> Self {
+    pub fn new(layer_aliases: HashMap<String, usize>, layers: Vec<Vec<(KeyCode, Action)>>, layer_profiles: HashMap<String, Profile>) -> Self {
         let mut converted: Vec<Layer> = vec![];
         for layer in layers.into_iter() {
             converted.push(layer.into_iter().collect::<Layer>());
@@ -35,6 +38,7 @@ impl Cfg {
         Self {
             layers: converted,
             layer_aliases,
+            layer_profiles,
             tap_hold_wait_time: 0,
             tap_dance_wait_time: 0,
         }

--- a/src/cfg.rs
+++ b/src/cfg.rs
@@ -29,7 +29,11 @@ pub struct Cfg {
 
 impl Cfg {
     #[cfg(test)]
-    pub fn new(layer_aliases: HashMap<String, usize>, layers: Vec<Vec<(KeyCode, Action)>>, layer_profiles: HashMap<String, Profile>) -> Self {
+    pub fn new(
+        layer_aliases: HashMap<String, usize>,
+        layers: Vec<Vec<(KeyCode, Action)>>,
+        layer_profiles: HashMap<String, Profile>,
+    ) -> Self {
         let mut converted: Vec<Layer> = vec![];
         for layer in layers.into_iter() {
             converted.push(layer.into_iter().collect::<Layer>());

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -27,7 +27,13 @@ pub enum Effect {
     Meh,   // Ctrl+Alt+Shift
     Hyper, // Ctrl+Alt+Shift+Win
 
+
+    ActivateProfile(String),
+    DeactivateProfile(String),
+    DeactivateAllProfiles,
+
     ToggleLayerAlias(String),
+
     ToggleLayer(LayerIndex),
     MomentaryLayer(LayerIndex),
 

--- a/src/effects/mod.rs
+++ b/src/effects/mod.rs
@@ -27,7 +27,6 @@ pub enum Effect {
     Meh,   // Ctrl+Alt+Shift
     Hyper, // Ctrl+Alt+Shift+Win
 
-
     ActivateProfile(String),
     DeactivateProfile(String),
     DeactivateAllProfiles,

--- a/src/effects/perform.rs
+++ b/src/effects/perform.rs
@@ -90,6 +90,24 @@ fn perform_toggle_layer_alias(ktrl: &mut Ktrl, name: String, value: KeyValue) ->
     Ok(())
 }
 
+fn perform_toggle_profile(ktrl: &mut Ktrl, name: String, value: KeyValue, on: bool) -> Result<(), Error> {
+    if value == KeyValue::Press {
+        ktrl.l_mgr.toggle_profile(name, on)
+    }
+
+    Ok(())
+}
+
+fn perform_toggle_all_profiles(ktrl: &mut Ktrl, value: KeyValue) -> Result<(), Error> {
+    if value == KeyValue::Press {
+        for name in ktrl.l_mgr.layer_profiles.clone().keys() {
+            ktrl.l_mgr.toggle_profile(name.clone(), false);
+        }
+    }
+
+    Ok(())
+}
+
 fn perform_key_sticky(ktrl: &mut Ktrl, code: KeyCode, value: KeyValue) -> Result<(), Error> {
     if value == KeyValue::Release {
         return Ok(());
@@ -124,6 +142,9 @@ pub fn perform_effect(ktrl: &mut Ktrl, fx_val: EffectValue) -> Result<(), Error>
         Effect::KeySticky(code) => perform_key_sticky(ktrl, code, fx_val.val),
         Effect::Meh => perform_keyseq(&mut ktrl.kbd_out, MEH.to_vec(), fx_val.val),
         Effect::Hyper => perform_keyseq(&mut ktrl.kbd_out, HYPER.to_vec(), fx_val.val),
+        Effect::ActivateProfile(name) => perform_toggle_profile(ktrl, name, fx_val.val, true),
+        Effect::DeactivateProfile(name) => perform_toggle_profile(ktrl, name, fx_val.val, false),
+        Effect::DeactivateAllProfiles => perform_toggle_all_profiles(ktrl, fx_val.val),
         Effect::ToggleLayer(idx) => perform_toggle_layer(ktrl, idx, fx_val.val),
         Effect::ToggleLayerAlias(name) => perform_toggle_layer_alias(ktrl, name, fx_val.val),
         Effect::MomentaryLayer(idx) => perform_momentary_layer(ktrl, idx, fx_val.val),

--- a/src/effects/perform.rs
+++ b/src/effects/perform.rs
@@ -90,12 +90,17 @@ fn perform_toggle_layer_alias(ktrl: &mut Ktrl, name: String, value: KeyValue) ->
     Ok(())
 }
 
-fn perform_toggle_profile(ktrl: &mut Ktrl, name: String, value: KeyValue, on: bool) -> Result<(), Error> {
+fn perform_toggle_profile(
+    ktrl: &mut Ktrl,
+    name: String,
+    value: KeyValue,
+    on: bool,
+) -> Result<(), Error> {
     if value == KeyValue::Press {
         // deactivate all profiles, if successful, activate new profile
         match perform_deactivate_all_profiles(ktrl, value) {
             Ok(()) => ktrl.l_mgr.toggle_profile(name, on),
-            Err(e) => return Err(e)
+            Err(e) => return Err(e),
         }
     }
 

--- a/src/effects/perform.rs
+++ b/src/effects/perform.rs
@@ -92,13 +92,17 @@ fn perform_toggle_layer_alias(ktrl: &mut Ktrl, name: String, value: KeyValue) ->
 
 fn perform_toggle_profile(ktrl: &mut Ktrl, name: String, value: KeyValue, on: bool) -> Result<(), Error> {
     if value == KeyValue::Press {
-        ktrl.l_mgr.toggle_profile(name, on)
+        // deactivate all profiles, if successful, activate new profile
+        match perform_deactivate_all_profiles(ktrl, value) {
+            Ok(()) => ktrl.l_mgr.toggle_profile(name, on),
+            Err(e) => return Err(e)
+        }
     }
 
     Ok(())
 }
 
-fn perform_toggle_all_profiles(ktrl: &mut Ktrl, value: KeyValue) -> Result<(), Error> {
+fn perform_deactivate_all_profiles(ktrl: &mut Ktrl, value: KeyValue) -> Result<(), Error> {
     if value == KeyValue::Press {
         for name in ktrl.l_mgr.layer_profiles.clone().keys() {
             ktrl.l_mgr.toggle_profile(name.clone(), false);
@@ -144,7 +148,7 @@ pub fn perform_effect(ktrl: &mut Ktrl, fx_val: EffectValue) -> Result<(), Error>
         Effect::Hyper => perform_keyseq(&mut ktrl.kbd_out, HYPER.to_vec(), fx_val.val),
         Effect::ActivateProfile(name) => perform_toggle_profile(ktrl, name, fx_val.val, true),
         Effect::DeactivateProfile(name) => perform_toggle_profile(ktrl, name, fx_val.val, false),
-        Effect::DeactivateAllProfiles => perform_toggle_all_profiles(ktrl, fx_val.val),
+        Effect::DeactivateAllProfiles => perform_deactivate_all_profiles(ktrl, fx_val.val),
         Effect::ToggleLayer(idx) => perform_toggle_layer(ktrl, idx, fx_val.val),
         Effect::ToggleLayerAlias(name) => perform_toggle_layer_alias(ktrl, name, fx_val.val),
         Effect::MomentaryLayer(idx) => perform_momentary_layer(ktrl, idx, fx_val.val),

--- a/src/ktrl.rs
+++ b/src/ktrl.rs
@@ -53,7 +53,7 @@ impl Ktrl {
 
         let cfg_str = read_to_string(args.config_path)?;
         let cfg = cfg::parse(&cfg_str);
-        let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases);
+        let mut l_mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases, &cfg.layer_profiles);
         l_mgr.init();
 
         let th_mgr = TapHoldMgr::new(cfg.tap_hold_wait_time);

--- a/src/layers.rs
+++ b/src/layers.rs
@@ -1,9 +1,9 @@
 use crate::keys::KeyCode::*;
 use log::{debug, warn};
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::vec::Vec;
-use serde::Deserialize;
 
 pub use crate::actions::tap_hold::TapHoldState;
 pub use crate::actions::Action;
@@ -101,7 +101,11 @@ fn init_merged() -> Merged {
 }
 
 impl LayersManager {
-    pub fn new(layers: &Layers, layer_aliases: &LayerAliases, layer_profiles: &LayerProfiles) -> Self {
+    pub fn new(
+        layers: &Layers,
+        layer_aliases: &LayerAliases,
+        layer_profiles: &LayerProfiles,
+    ) -> Self {
         let merged = init_merged();
         let layers = layers.clone();
         let layer_aliases = layer_aliases.clone();
@@ -396,7 +400,6 @@ fn test_mgr() {
                 (KEY_LEFTCTRL, Tap(Key(KEY_CAPSLOCK))),
                 (KEY_CAPSLOCK, Tap(Key(KEY_LEFTCTRL))),
             ],
-
             // 1: arrows layer
             vec![
                 // Ex: switch CTRL <--> Capslock
@@ -405,7 +408,6 @@ fn test_mgr() {
                 (KEY_K, Tap(Key(KEY_UP))),
                 (KEY_L, Tap(Key(KEY_RIGHT))),
             ],
-
             // 2: asdf modifiers
             vec![
                 // Ex: switch CTRL <--> Capslock
@@ -413,8 +415,8 @@ fn test_mgr() {
                 (KEY_S, TapHold(Key(KEY_S), Key(KEY_LEFTSHIFT))),
                 (KEY_D, TapHold(Key(KEY_D), Key(KEY_LEFTALT))),
             ],
-    ],
-    HashMap::new(),
+        ],
+        HashMap::new(),
     );
 
     let mut mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases, &cfg.layer_profiles);
@@ -507,17 +509,12 @@ fn test_overlapping_keys() {
         h,
         vec![
             // 0: base layer
-            vec![
-                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))),
-            ],
-
+            vec![(KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT)))],
             // 1: arrows layer
             // Ex: switch CTRL <--> Capslock
-            vec![
-                (KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT))),
-            ]
+            vec![(KEY_A, TapHold(Key(KEY_A), Key(KEY_LEFTSHIFT)))],
         ],
-        HashMap::new()
+        HashMap::new(),
     );
 
     let mut mgr = LayersManager::new(&cfg.layers, &cfg.layer_aliases, &cfg.layer_profiles);


### PR DESCRIPTION
Added profile support. Adds 3 `Effect`s - `ActivateProfile` `DeactivateProfile` and `DeactivateAllProfiles`.

Allows you to define a profile as having aliases or indexes explicitly enabled or disabled. This is done to avoid making users manage layers and instead focus on keybinding conflict resolution.

Let me know your thoughts on structure/what you would like changed