### PR TITLE
Allow listening on multiple devices simultaneously

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ H: Handlers=sysrq kbd event25 leds
 ```
 Notice in `Handlers`, it tells us the event # we need. So our path to our device is `/dev/input/event25`.
 
+#### Listening on all input devices
+
+If you still can not figure out which device to use, or want to map events from
+several devices, you can pass all (or chosen) devices as an arg:
+```
+--device /dev/input/event*
+# or
+--device /dev/input/event2 /dev/input/event10
+```
 
 #### Setting up ktrl as a Service (Optional)
 
@@ -305,6 +314,14 @@ KEY_D:  TapHold(Key(KEY_D), Key(KEY_LEFTALT)),
 ```
 
 This will make `A`, `S` and `D` act as usual on taps and as modifiers when held.
+
+### Remap mouse button to control musical player
+
+If you have a mouse with a side buttons, you can remap a button to act as a media button.
+This example shows how to map tap to play/pause and long tap to next song:
+```
+BTN_SIDE: TapHold(Key(KEY_PLAYPAUSE), Key(KEY_NEXTSONG))
+```
 
 ##  Limitations
 

--- a/src/kbd_in.rs
+++ b/src/kbd_in.rs
@@ -4,6 +4,7 @@ use evdev_rs::GrabMode;
 use evdev_rs::InputEvent;
 use evdev_rs::ReadFlag;
 use evdev_rs::ReadStatus;
+use evdev_rs::enums::EventType;
 
 use std::fs::File;
 use std::path::Path;
@@ -16,6 +17,11 @@ impl KbdIn {
     pub fn new(dev_path: &Path) -> Result<Self, std::io::Error> {
         let kbd_in_file = File::open(dev_path)?;
         let mut kbd_in_dev = Device::new_from_fd(kbd_in_file)?;
+        if kbd_in_dev.has(&EventType::EV_ABS) {
+            // this blocks all hotkeys, including ctrl-c
+            log::error!("Skip device {dev_path:?}: touchapd is not supporded");
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, "touchpad"));
+        }
 
         // NOTE: This grab-ungrab-grab sequence magically
         // fix an issue I had with my Lenovo Yoga trackpad not working.

--- a/src/kbd_out.rs
+++ b/src/kbd_out.rs
@@ -38,9 +38,17 @@ impl KbdOut {
         unsafe {
             uinput_sys::ui_set_evbit(uinput_out_file.as_raw_fd(), uinput_sys::EV_SYN);
             uinput_sys::ui_set_evbit(uinput_out_file.as_raw_fd(), uinput_sys::EV_KEY);
+            uinput_sys::ui_set_evbit(uinput_out_file.as_raw_fd(), uinput_sys::EV_REL);
+            uinput_sys::ui_set_evbit(uinput_out_file.as_raw_fd(), uinput_sys::EV_MSC);
 
             for key in 0..uinput_sys::KEY_MAX {
                 uinput_sys::ui_set_keybit(uinput_out_file.as_raw_fd(), key);
+            }
+            for key in 0..uinput_sys::REL_MAX {
+                uinput_sys::ui_set_relbit(uinput_out_file.as_raw_fd(), key);
+            }
+            for key in 0..uinput_sys::MSC_MAX {
+                uinput_sys::ui_set_mscbit(uinput_out_file.as_raw_fd(), key);
             }
 
             let mut uidev: uinput_user_dev = mem::zeroed();


### PR DESCRIPTION
This PR adds support for listening on multiple devices at once and forwads mouse events to kbd_out

Rationale for this PR is the following: I have a mouse with side buttons, that act as forwadr/backward by default, which I found pretty useless. I wanted to remap them to media pause/media next, and you app seems like the most suitable